### PR TITLE
Add Step 4 git safety check to /onboard before closing screen

### DIFF
--- a/.claude/skills/onboard/SKILL.md
+++ b/.claude/skills/onboard/SKILL.md
@@ -66,7 +66,44 @@ Once the intake is complete, generate these files (or update if re-running). Bac
 5. **`connections.md`** — populate the 7-row table from Q4-Q7 answers. Each row gets `mechanism: not yet connected`, `auth: —`, `last checked: —`. The user wires connections on Day 2.
 6. **`CLAUDE.md`** — fill all `{{...}}` placeholders. Substitute the user's name, stated priority, voice register summary, and a brief connections summary.
 
-### Step 4: The closing screen
+### Step 4: Git safety check
+
+Before printing the closing screen, run:
+
+```
+git remote -v
+```
+
+Branch on the result:
+
+- **No remote configured** → proceed to Step 5 silently. No extra output.
+- **One or more remotes configured** → print the warning below verbatim
+  and pause for the user to acknowledge before continuing to Step 5.
+
+```
+WARNING — this repo has a git remote.
+
+Onboarding just wrote personal business data into:
+  - aios-intake.md       (identity, ICP, priorities)
+  - CLAUDE.md            (your operating manual)
+  - connections.md       (every tool you reach + how it auths)
+  - context/             (about you, business, priorities)
+  - references/voice.md  (verbatim writing samples — impersonation risk)
+  - decisions/log.md     (your decision history, from now on)
+
+Before pushing:
+  1. Confirm this repo is PRIVATE on the remote host.
+  2. Run `git status` and audit what's staged.
+  3. If you want to keep tracking upstream template updates without
+     committing your local edits, run:
+        git update-index --skip-worktree CLAUDE.md aios-intake.md \
+                                         connections.md decisions/log.md
+```
+
+Do not push, commit, or stage anything on the user's behalf — this step
+is informational. The user owns the decision.
+
+### Step 5: The closing screen
 
 Print one screen. Three lines max:
 
@@ -95,11 +132,13 @@ The Default Shift question seeds the Mindset framework before `/level-up` formal
 6. **No extra skills generated.** Don't scaffold `/today`, `/draft`, `/connect`, etc. The kit ships 3 skills; the user authors more via `/level-up`.
 7. **Read-only on `references/3ms-framework.md`.** It already ships in the kit. Don't overwrite.
 8. **No `.env` writes.** Don't ask for API keys on Day 1. Connections come Day 2.
+9. **Git safety check is unconditional.** Step 4 runs every time, including idempotent re-runs. Print the warning when a remote is configured; stay silent when none is.
 
 ## Verification (for the implementer)
 
 - Cold-test: clone a fresh kit, run `/onboard`, fill 7 answers, scaffold runs, ask the wow prompt, response cites Q1 + Q3 + Q7 specifically. Generic = fail.
 - Idempotency: re-run `/onboard` with one Q3 priority changed. Expected: only `context/priorities.md` and `CLAUDE.md`'s priority section update; backup created in `archives/intake-{ts}/`.
 - Voice rejection: type a sample mid-chat. Expected: skill refuses, asks for paste.
+- Git remote present: configure a remote, run `/onboard`, expected: warning printed before closing screen. Remove remote, re-run, expected: no extra output between Step 3 and the closing screen.
 
 > *Adapted from The Three Ms of AI™ © 2026 Nate Herk. The Mindset language used in the closing screen comes from `references/3ms-framework.md`.*


### PR DESCRIPTION
## What this changes

Adds a `### Step 4: Git safety check` to `/onboard/SKILL.md` between the scaffold step (Step 3) and the closing screen (renumbered Step 5).

The step:

1. Runs `git remote -v`
2. **No remote** → proceeds to Step 5 silently
3. **Remote present** → prints a verbatim warning naming each file `/onboard` just wrote, recommends a private repo, points at `git status`, and offers `git update-index --skip-worktree` for users who want to keep editing locally without committing

Also adds:

- Implementation rule #9 making the check unconditional (runs on idempotent re-runs too)
- Verification line covering both the remote-present and no-remote paths

## Why

By the time `/onboard` finishes, the kit has written business identity, ICP, quarterly priorities, the tool/auth registry, and verbatim writing samples across `CLAUDE.md`, `aios-intake.md`, `connections.md`, `context/`, `references/voice.md`, and `decisions/log.md`. The README's Quick Start tells users to "clone the repo to a working folder" — many will leave the original GitHub remote attached or push the working folder to a new remote without thinking.

The most dangerous moment is the same moment as the wow moment: completion. The user has just felt the kit work, and the very next thing they want is to share or back up their setup. They reach for `git push` before they've registered that the files now contain personal data. A check at that exact moment is the highest-leverage warning point — and it costs nothing when no remote is configured (zero extra output).

## What this does NOT change

- Step 4 is **informational only**. The skill does not push, commit, or stage anything on the user's behalf.
- No other steps modified — Step 1, 2, 3 are byte-identical
- The closing screen content is byte-identical (just renumbered Step 4 → Step 5)
- No `.gitignore` or other file changes (handled by PR #1)
- No CLAUDE.md changes (handled by PR #2)

## Test plan

- **Remote present:** clone the kit, `git remote add origin <something>`, run `/onboard`, expected: warning printed between Step 3 and closing screen, listing all six personal-data surfaces
- **No remote:** clone the kit, `git remote remove origin`, run `/onboard`, expected: zero extra output between scaffold and closing screen
- **Idempotent re-run with remote:** re-run after a Q3 edit, expected: warning still prints (rule #9)
- **Re-numbering smoke test:** confirm grep `^### Step` shows Steps 1, 2, 3, 4, 5 in order

## Related

This is the third and final PR of the security-hardening series:

- PR #1 — Defensive: `.gitignore` expansion + warning banners on tracked templates
- PR #2 — Trust Boundary section in `CLAUDE.md` + Security guidance in `EXPANSIONS.md`
- PR #3 (this one) — `/onboard` runtime check at the highest-leverage warning point

The three PRs are independent and can land in any order. Together they cover the prompt-injection surface (PR #2), the gitignore surface (PR #1), the static documentation surface (PR #1 banners + PR #2 EXPANSIONS section), and the runtime warning surface (PR #3).
