### PR TITLE
docs(README): drop reference to non-existent /decision skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The kit is intentionally lean. Skills here are ideation prompts and thinking too
 
 1. **Clone the repo** to a working folder on your machine.
 2. **Open it in Claude Code** and run `/onboard`. Answer the 7 questions honestly. Voice samples must be pasted, not described. Takes ~15 minutes. Day-1 file set drops at the end.
-3. **Use it for a week.** Bring real questions. Make real decisions. Log them via `/decision` (or just append to `decisions/log.md`).
+3. **Use it for a week.** Bring real questions. Make real decisions. Log them by appending to `decisions/log.md`.
 4. **Day 7:** run `/audit`. Read the Four-Cs gap report. Pick one gap to close.
 5. **Day 14:** run `/level-up`. The Three Ms interview surfaces one automation worth building. Build it.
 6. **Week 3+:** weekly `/level-up` ritual. One shipped artifact per week.


### PR DESCRIPTION
## Issue

In Quick Start step 3 the README tells users:

> Log them via \`/decision\` (or just append to \`decisions/log.md\`).

But no \`/decision\` skill ships in this repo. The 'What ships — 3 skills' table earlier in the README lists only \`/onboard\`, \`/audit\`, and \`/level-up\` — and \`.claude/skills/\` confirms (only those three directories exist). New users who try \`/decision\` will hit a 'skill not found' error on a freshly cloned repo, which is a rough first-day moment.

## Fix

Drop the \`/decision\` reference and keep the still-valid instruction to append to \`decisions/log.md\` directly. One-line README change, no semantic loss.

## Verification

- \`grep -rn "/decision" .\` after the change returns nothing.
- All three documented skills are unaffected.