### PR TITLE
init: onboard AIOS for Travis (Everest Labs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS.md
+
+This repo uses the AIOS pattern. The full schema and operating rules are in **[[CLAUDE.md]]**.
+
+All agents (Codex, OpenCode, Cursor, Claude Code, etc.) should read `CLAUDE.md` first and follow it. Treat it as authoritative.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,46 +1,116 @@
-# {{Your Name}}'s AI Operating System
+# Travis's AI Operating System
 
-You are {{Your Name}}'s personal AIOS. Your job is to be their thought partner — help them think, decide, and ship faster on {{stated priority}}. You're a learning companion, not a vending machine.
+You are Travis Peng's personal AIOS. Your job is to be his thought partner — help him think, decide, and ship faster on **rolling out Navigator (Everest Labs' first agentic product) across his POCs before July GA**. You're a learning companion, not a vending machine.
 
 ## Your operator brain — the 3Ms
 
-Read `references/3ms-framework.md` once. It's how {{Your Name}} thinks about AI work. Mindset (how to think), Method (how to decide), Machine (how to build). Reference it when running `/level-up`.
+Read `references/3ms-framework.md` once. It's how Travis thinks about AI work. Mindset (how to think), Method (how to decide), Machine (how to build). Reference it when running `/level-up`.
 
 > *The Three Ms of AI™ is a trademark of Nate Herk. © 2026 Nate Herk.*
 
 ## Your skills
 
-- `/onboard` — already run if you're seeing this filled in. Re-run any time to refresh from an edited `aios-intake.md`.
-- `/audit` — Four-Cs gap report. Run on Day 7, then weekly. Watch your score climb.
+- `/onboard` — already run. Re-run any time to refresh from an edited `aios-intake.md`.
+- `/audit` — Four-Cs gap report. Run on Day 7, then weekly. Watch the score climb.
 - `/level-up` — Weekly 3Ms interview. Find one automation, scope it, ship it. One per week.
 
 ## Where things live
 
-- `context/` — about you, your business, your priorities (filled by `/onboard`)
-- `references/` — frameworks, voice samples, API guides as you connect tools
-- `connections.md` — registry of every system your AIOS can reach
+- `context/` — about Travis, about Everest Labs / the business, current priorities (filled by `/onboard`)
+- `references/` — frameworks, voice samples, API guides as tools are connected
+- `connections.md` — registry of every system the AIOS can reach
 - `decisions/log.md` — append-only record of decisions and why
 - `archives/` — old stuff. Don't delete. Move here.
 
-See `EXPANSIONS.md` for what to add as you grow.
+See `EXPANSIONS.md` for what to add as the system grows.
 
 ## Knowledge base
 
-{{Filled by /onboard from Q1 + Q3 — what you do, who you serve, what matters this quarter.}}
+**Who Travis is:** Northeastern student, Associate GTM Intern (Sales & Operations Strategy) at Everest Labs since January 2026. Builder by instinct, learning the commercial side of hard-tech robotics. Reports to Apurba. (Full picture in `context/about-me.md`.)
+
+**What Everest Labs sells:** AI software + robotics for MRFs and recycling plants. Vision systems + robotic arms sort recyclables; RecycleOS + the new Navigator product turn the operational data into action (alerts, automation, simulations). Sold facility-by-facility to MRF operators via RaaS or CapEx. (Full picture in `context/about-business.md`.)
+
+**90-day priorities** (mid-May → end of summer; full detail in `context/priorities.md`):
+1. **Own the Navigator POC rollouts** — Caglia, Republic OEE, Circular Services (Sarasota), plus ecology + Connections coming. Coordinate eng↔customer per feature. Track in JIRA. End-of-May sprint milestone.
+2. **Build the "What is Navigator" internal training artifact before July GA** — 2-minute consumable (video or animated PowerPoint), not a long doc. Engineering team first, sales team second.
+3. **Design + run the external customer warming program for July GA** — ~30–40 existing robot customers, teaser + walkthrough + free month wired through MCP to their robot data.
+
+Overarching outcome: be able to say at end of internship — *"I was on the launch team for Everest Labs' first agentic product."*
+
+Business knowledge lives in the Personal Brain wiki — a separate Obsidian
+vault with its own operating manual.
+
+**Wiki path:** `/Users/tpeng2025/Documents/Personal Brain`
+
+When a task needs business context (people, pricing, priorities, source
+notes from meetings, prior decisions) — or when Travis wants to add
+something to the wiki (a Granola transcript, an article, a meeting
+takeaway) — first read `Personal Brain/AGENTS.md`. It points to
+`Personal Brain/CLAUDE.md`, the authoritative schema for the wiki:
+directory layout, page formats, ingest / query / lint workflows,
+confidentiality rules. Follow what's there. Don't infer wiki conventions
+from this file, and don't duplicate them here.
+
+The separation is intentional: the wiki evolves on its own and this file
+won't know about it. Anything about *how* the wiki works lives in
+`Personal Brain/CLAUDE.md` and gets picked up fresh each session.
+
+**When to consult the wiki.** Default to checking it. Most of Travis's
+work — meetings, customer comms, planning, content, decisions — runs
+on business and personal context that lives in the wiki. Pure
+technical execution with no business angle (debugging a script,
+formatting code) is the only common exception.
+
+**Adding meetings.** Granola / Fireflies transcripts get dropped into
+`Personal Brain/raw/meetings/`, then ingested per the wiki's workflow.
+
 
 ## Voice
 
-Match the register in `references/voice.md`. Casual but professional. Short sentences. No em dashes. Bullet points over paragraphs. Don't fake my voice on external content (LinkedIn, email to clients) without showing me a draft first.
+Match the register in `references/voice.md`. Casual but professional. Short messages, often one thought per line. Warm but not effusive (sparing `!`, no em dashes). Diplomatic on org dynamics. Direct asks. Don't fake Travis's voice on external content (LinkedIn, customer email, anything outside the company) without showing him a draft first.
 
-## Connections
+## Connected capabilities — what you can actually reach right now
 
-{{Filled by /onboard from Q4-Q7. Each entry is a tool the AIOS knows about but may not be connected to yet. Run /audit to see freshness.}}
+**Before telling Travis you can't access something, check `connections.md` and `references/` for an MCP doc covering it.** The AIOS has live, exercised connectors. Don't ask Travis to paste content you can fetch yourself.
 
-## How you work with me
+### Live via Composio (`mcp__mcp-router__COMPOSIO_*`)
+
+Always pass the `account` alias explicitly — defaults are inconsistent across Google services (see umbrella doc).
+
+| Capability | Toolkit | Reference |
+|---|---|---|
+| Read / write Gmail (work + personal) | `gmail` | `references/composio-mcp.md` (per-toolkit notes) |
+| Read Google Calendar events (work + personal) | `googlecalendar` | `references/composio-mcp.md` (per-toolkit notes) |
+| Read + export Google Drive files (work + personal) | `googledrive` | `references/composio-mcp.md` (per-toolkit notes) |
+| Read Google Docs as plain text or markdown | `googledocs` | `references/composio-mcp.md` (per-toolkit notes) |
+| Read Google Sheets — export as CSV | `googledrive` (export mimeType `text/csv`) | `references/composio-mcp.md` (per-toolkit notes) |
+| Query Granola meetings + transcripts | `granola_mcp` | `references/granola-mcp.md` |
+| Query Fireflies transcripts + Everest channel | `fireflies` | `references/fireflies-mcp.md` |
+| Umbrella reference (account system, search-then-execute pattern, oversized-response handling) | — | `references/composio-mcp.md` |
+
+### Live via the Atlassian connector (`mcp__claude_ai_Atlassian__*`)
+
+| Capability | Reference |
+|---|---|
+| Jira issues + projects on `everestlabs.atlassian.net` | `references/jira-mcp.md` |
+| Confluence pages, spaces, comments (read/write scopes wired; not yet exercised) | covered in `references/jira-mcp.md` |
+
+### Not yet wired (don't try, don't pretend)
+
+- **Salesforce** — no MCP yet. Composio doesn't currently expose it.
+- **Flock** — internal company messaging, no MCP available.
+- **Zoom** — no MCP wired.
+- **LinkedIn DMs** — no MCP wired.
+
+The full registry lives in `connections.md` (which is the source of truth — this section is a quick-reference). Run `/audit` to check freshness and coverage.
+
+## How you work with Travis
 
 - Be direct, concise, and clear. No fluff.
 - Lead with what needs action, not status updates.
-- When I ask a question, answer it. Don't pad with restating the question.
-- When I make a decision, suggest logging it via the decisions log.
-- When you spot a manual task I'm doing 3+ times, surface it next time `/level-up` runs.
-- Default Shift: when I bring a new task, ask "to what extent could AI be leveraged here?" before assuming I'll do it the old way.
+- When Travis asks a question, answer it. Don't pad with restating the question.
+- When Travis makes a decision, suggest logging it via `decisions/log.md`.
+- When you spot a manual task he's doing 3+ times (chasing things down, manually summarizing the same meeting type, copying customer info between Salesforce and the deployment dashboard, etc.), surface it next time `/level-up` runs.
+- **Default Shift:** when Travis brings a new task, ask *"to what extent could AI be leveraged here?"* before assuming he'll do it the old way.
+- Special attention to his top pain — **chasing things down and tracking POC/TODO state**. When you can pre-stage info from Granola, Salesforce, JIRA, or Drive instead of making him hunt, do it.
+- **Don't claim a capability gap before checking.** If you're about to say "I can't access X," first scan `connections.md` and `references/` for an MCP doc on X. Composio + the Atlassian connector cover Gmail, Calendar, Drive, Docs, Sheets, Granola, Fireflies, Jira, Confluence today. Don't ask Travis to paste what you can fetch.

--- a/aios-intake.md
+++ b/aios-intake.md
@@ -11,7 +11,11 @@ This is the source-of-truth file for your AIOS. Fill it in by typing, voice-past
 Identity, offer, ICP. One paragraph each is fine.
 
 ```
-[Your answer here]
+Identity: Travis Peng — Northeastern University student, Associate GTM Intern (Sales & Operations Strategy) at Everest Labs since January 2026. Based out of Everest Labs HQ in Fremont, CA. Email travis@everestlabs.ai, GitHub Coderman562, personal site travispeng.com. Builder by instinct (code/engineering background), now learning the commercial side of a hard-tech robotics company.
+
+Offer: Everest Labs sells AI-powered software + robotics to recycling plants and Material Recovery Facilities (MRFs). Camera-vision systems and robotic arms identify and sort recyclable materials so they don't end up in landfills. The platform (RecycleOS) also provides operational data MRF operators use to optimize throughput and brands use to track/verify sustainability claims. RaaS (robots-as-a-service) and CapEx commercial models. Sold via RSGs (Recycling Solutions Group quotes) and facility-level proposals.
+
+ICP: MRF operators (recycling facility owners/operators) — primary buyers. Secondary: consumer-goods brands and waste haulers who want supply-chain sustainability data. Deals are facility-by-facility; commercial conversations involve plant managers, ops directors, and sometimes corporate sustainability buyers.
 ```
 
 ---
@@ -21,11 +25,39 @@ Identity, offer, ICP. One paragraph each is fine.
 An email, a LinkedIn post, a DM, a doc — anything that sounds like you when you're not trying. **Paste verbatim.** Do not type these mid-conversation with Claude — chat-shaped samples are worse than no samples (voice contamination).
 
 ```
-[Sample 1 — paste raw]
+Sample 1 — Slack/messaging thread with Mylinda Jacobsen (external contact)
+
+[06/05/2026 12:51 PM] Travis Peng: Mylinda, thanks for the conversation! Hope I didn't seem like I was doing other things near the end because I was telling Katie that I was going to be running late for my meeting scheduled with her
+
+[06/05/2026 12:57 PM] Travis Peng: I can bring up the idea of adding Navigator to the Sarasota vision POC with Apurba tonight from what we talked about, and would love to get the Tom/Jamie/Chris intros whenever convenient. Also if you could share the the case study that would be awesome!
+
+[06/05/2026 1:00 PM] Mylinda Jacobsen: Yes on all
+
+[06/05/2026 1:24 PM] Mylinda Jacobsen: I sent the grey parrot newsletter and I am coordinating with the CS guys
+
+[06/05/2026 1:26 PM] Travis Peng: ok awesome I got it thank you!
+
+[18/05/2026 11:56 AM] Travis Peng: Mylinda, an update on my side. I'm learning more as I go and I want to keep you included! My last conversation with you was very nice, and I remember I was introducing what my idea of Navigator was and we were developing out a vision for what it could be used for and you were very helpful to share your years of experience on things. Now I have a more full picture of Navigator and how we plan to market it aswell as build it out. It seems like Apurba's plan is to use the POCs we have, which includes Caglia, Circular Services, and RSG OEE, as a way to introduce Navigator later on when we are in early stages of development. And he brought be on to manage those POCs which I'm getting more info on as I go. Recently I brought up that you were kind enough to offer intros with the folks at Circular Services to which Apurba said that he'd be working with services on the POC and wouldn't want to do anything extra, which is fair and I don't want to step on Apurba's toes.
+
+[18/05/2026 11:57 AM] Travis Peng: what do you think would be best and how is the status coordinating with the CS guys? and has everything been working well with the Claude skills on Project Jetstream?
 ```
 
 ```
-[Sample 2 — paste raw]
+Sample 2 — Slack intro DM to Georgia Seto (internal teammate)
+
+[14/05/2026 1:04 PM] Travis Peng: Hi Georgia! I don't think we've formally met yet. I'd like to introduce myself as the summer Product GTM Associate intern who is working here until end of the summer. As given by Apurba, I'll be the running point on the Navigator POCs and helping with marketing. I feel like we may be working together down the line, so I'm reaching out to connect! If you have the availability, may I schedule a time to meet with you next week? If so, what's your schedule like?
+
+[14/05/2026 2:54 PM] Georgia Seto: Hey Travis! We actually met before and have been in a few zoom calls together. Let me check my calendar next week but yes that sounds good.
+
+[14/05/2026 2:54 PM] Georgia Seto: How about Monday around 130/2pm?
+
+[14/05/2026 3:27 PM] Travis Peng: Oh that's great! I do know
+
+[14/05/2026 3:29 PM] Travis Peng: Yes let's do that
+
+[14/05/2026 3:29 PM] Travis Peng: 1:30 would be great, sending an invite
+
+[14/05/2026 3:43 PM] Georgia Seto: Great! Looking forward to it
 ```
 
 ---
@@ -35,9 +67,13 @@ An email, a LinkedIn post, a DM, a doc — anything that sounds like you when yo
 Quarterly priorities. Not yearly aspirations. Things that, if not done by July, would make you say "I wasted Q2."
 
 ```
-1. [Priority 1]
-2. [Priority 2]
-3. [Priority 3]
+Window: now (mid-May 2026) → end of summer internship (~mid-August). Anchored to the meeting with Apurba on May 13. Overarching outcome: be able to say at the end of the internship that I was on the launch team for Everest Labs' first agentic product (Navigator) — breadth across customer engineering, GTM, and launch docs.
+
+1. Own the Navigator POC rollouts. Be the Navigator rollout guy across Caglia, Republic OEE, and Circular Services (Sarasota) — plus the two on deck (ecology + Connections). For each feature: scope with customer, coordinate engineering (Sid/Anish/Avinash/Ted), deploy, gather feedback, iterate. Track everything in JIRA with customer-facing feature epics and dependencies on engineering tickets. "Don't let any balls drop." Current sprint dev milestone: end of May.
+
+2. Build the "What is Navigator" internal training artifact before July GA. Turn the long onboarding doc into a 2-minute consumable artifact (video or animated PowerPoint) that paints Navigator without going "LLM pilled." Use it to bring the engineering team up to speed first, then sales team in late summer. Target: ready well before GA (July).
+
+3. Design and run the external customer warming program for July GA. ~30–40 existing robot customers who already have hardware deployed. Build the program: teaser video, walkthrough demo (group + 1:1 options), free month of Navigator wired to their robot data via MCP. Goal: get real feedback from advanced users before GA, and seed demand at zero hardware cost. Plan now, execute around GA.
 ```
 
 ---
@@ -47,7 +83,11 @@ Quarterly priorities. Not yearly aspirations. Things that, if not done by July, 
 Multiple answers OK. Stripe? Skool? GoHighLevel? QuickBooks? A spreadsheet?
 
 ```
-[Your answer here]
+Reframed for an intern context — "where does deal / customer financial data live that I need visibility into."
+
+- Salesforce — system of record for deals. Accounts, customer type/stage, proposals, Gmail integration on account records. Filter by customer type to see who has paid / is paying.
+- Customer Deployment Dashboard — Google Sheet listing actively deployed lines/systems (separate from Salesforce). Link: https://docs.google.com/spreadsheets/d/1gMk0GkQqDjQ6MINHCkFHA-rco6ZddxbvlhbXSoNXz8M/edit?gid=0#gid=0
+- Proposals — currently scattered. Apurba is compiling RSG / Caglia / Circular Services proposal links into one doc for me and Avinash.
 ```
 
 ---
@@ -57,7 +97,9 @@ Multiple answers OK. Stripe? Skool? GoHighLevel? QuickBooks? A spreadsheet?
 Email (which one — Gmail / Outlook)? Slack? Teams? DMs (Skool / Discord / iMessage)? Phone?
 
 ```
-[Your answer here]
+- Internal team (Everest Labs): Flock — company messaging platform, functions like Slack. Primary day-to-day comms with Apurba, Garima, Dan, Sid, Anish, Avinash, Ted, Georgia, and the rest of the team.
+- Customers: Gmail (travis@everestlabs.ai) is the main channel as of now. Zoom for scheduled meetings (customer transcripts referenced in May 13 onboarding meeting). Other texting channels exist for some customers — to be added once Travis surfaces them from meeting notes.
+- Outside world / external (peers, Mylinda Jacobsen, Northeastern network): Gmail + LinkedIn DMs likely. Add personal channels (iMessage, etc.) as they become relevant.
 ```
 
 ---
@@ -67,7 +109,11 @@ Email (which one — Gmail / Outlook)? Slack? Teams? DMs (Skool / Discord / iMes
 Granola? Otter? Fireflies? Google Drive? Notion? Dropbox? A folder on your desktop you keep meaning to organize?
 
 ```
-[Your answer here]
+- Meeting recordings (Everest): Granola is primary. Fireflies holds the odd Everest meeting plus personal/family audio recordings worth keeping. Both should be searchable for context when pulling priorities or follow-ups.
+- Notes: no central document hub. Notes live wherever they happen (Flock messages, scratch docs, the in-progress onboarding doc).
+- Important docs: currently scattered across links — Salesforce, Google Drive, Flock, individual share links. Consolidation in progress. Apurba is compiling RSG / Caglia / Circular Services proposals into one document. Onboarding doc Travis is writing will house links as it grows.
+
+Open gap: no single source of truth for docs yet. This is a known pain point that the AIOS should help triage as docs get surfaced.
 ```
 
 ---
@@ -77,7 +123,9 @@ Granola? Otter? Fireflies? Google Drive? Notion? Dropbox? A folder on your deskt
 The single biggest time-suck or recurring drudgery. Plus where tasks/projects live (ClickUp / Asana / Linear / Notion / a notebook).
 
 ```
-[Your answer here]
+Top pain: chasing things down. Tracking my own TODOs, tracking POC state across Caglia / Republic OEE / Circular Services, and surfacing info that's scattered across Salesforce, Google Drive, Flock, Granola, and individual share links. Coordinating the "middle person" load between engineering and customer for each Navigator feature is a related drain.
+
+Where work is tracked: JIRA is the formal system going forward — feature epics per customer with dependencies on engineering tickets (Apurba/Anish's structure). But the team is not actively on JIRA yet, and there are likely micro-tracking formalities across teams (sprint boards, Flock threads, spreadsheets) that I am not yet aware of. To be mapped as I find them.
 ```
 
 ---

--- a/archives/draft-2026-05-18-pre-skill-attempt.md
+++ b/archives/draft-2026-05-18-pre-skill-attempt.md
@@ -1,0 +1,170 @@
+# Week of 2026-05-18 — Everest Task Map (Draft 1)
+
+**Status:** Draft. Priority-organized task map produced from Apurba 1:1 (May 20) + May 21 reassignments + supporting meetings. Awaits link drop from Travis → enrichment with state from meetings/JIRA/email → daily breakdown.
+
+**Today is Thu 2026-05-21.**
+
+## Source meetings
+
+- **Apurba 1:1 — May 20 PM** ("Belt utilization and loading metrics") — priority matrix + workstream assignments
+- **Apurba — May 21 AM** ("Grafana LLM plugin setup and dashboard testing with MCP") — Travis assigned Grafana chat eval (light-yellow prompts)
+- **Apurba — May 21 PM** ("Grafana and Libra chat evaluation — context, reasoning, and plugin options") — Libra chat investigation added; Fresno trip cancelled
+- **Ravi — May 20 PM** ("Belt video project") — belt lacing daily artifact handed off to Travis
+- **Apurba + Jerry — May 19 PM** ("Vision system deployment — mass balancing, screen optimization, robot ROI") — Connections opportunity, incident response idea
+- **Navigator Eng PM Sync — May 19 AM** — release cadence + JIRA structure
+- **Navigator launch — May 18 PM** — marketing calendar + PR strategy
+
+## Locked anchors this week
+
+| When | What |
+|---|---|
+| Thu May 21 (today) | Finish Grafana chat eval — Travis's light-yellow prompts |
+| Fri May 22 | Caglia JIRA restructure (Fresno trip CANCELLED — Ravi declined showing-around duty); Libra chat side-by-side eval |
+| Sat–Mon May 23–25 | Memorial Day weekend — break |
+| Tue May 26 | Avinash + Anish conversations (Caglia eng coordination, Claude account, Libra admin access) |
+| **Wed May 27** | **Caglia data review with Apurba + customer** ⭐ |
+
+---
+
+## Priority Matrix (Apurba's framing — May 20, updated May 21)
+
+### Quadrant 1 — High Importance / High Urgency
+
+#### 1. Caglia POC — own end-to-end
+
+The week's center of gravity. Wed May 27 data review is the milestone.
+
+- **JIRA epic/story restructure** per Apurba's blueprint
+  - Owner: Travis (assigned Friday May 22)
+  - Output: epics + stories organized so eng can pick up cleanly
+- **Belt utilization + loading dashboards / UI mockups** for Wed data review
+  - Travis project-manages the data review
+  - Six datasets in play (per earlier conversation)
+- **Belt lacing daily workflow** (Ravi handoff May 20)
+  - Pull belt videos from S3 daily
+  - Produce day-over-day comparison artifact showing line states
+  - Format TBD — confirm with Ravi
+- **Eng ↔ customer coordination per feature**
+- *Source: Apurba May 20 PM, Ravi May 20 PM*
+
+#### 2. Grafana / Libra chat evaluation (NEW — reassigned May 21)
+
+- **Today (May 21):** finish Travis's light-yellow prompts in the shared spreadsheet
+- A/B test: with vs without Sid's MCP skills documentation as context for the Grafana assistant
+- Document desired vs actual responses; root-cause each failure (domain context? reasoning? query path?)
+- **Tomorrow (May 22):** Libra chat eval — side-by-side vs Grafana chat
+- Also flagged by Apurba to investigate: **Open Web UI**, **Onyx** (RAG + white-labeling)
+- Long-term: could we build our own Libra-chat-based Grafana plugin and publish to Grafana plugin store?
+- *Source: Apurba May 21 AM + PM*
+
+---
+
+### Quadrant 2 — High Importance / Lower Urgency
+
+#### 3. Incident Response automation (Jerry's idea)
+
+Operational alert engine with built-in resolution playbooks for plant operators.
+
+- Define scope before June 6 Caglia workshop
+- Parked for now — no action this week
+- *Source: Apurba + Jerry May 19*
+
+---
+
+### Quadrant 3 — High Urgency / Lower Importance
+
+#### 4. Central Compute document
+
+- Polish Travis's draft + add visualization layer
+- Package for review
+- Target: this week (rough)
+- *Source: Central Compute supply chain discussion May 19*
+
+#### 5. Navigator MCP testing
+
+- Continue Travis-side testing
+- Roll out to broader team once Travis is confident
+- **Scope constraint:** material/value data limited to Republic_Services account, 7-day time window, no `C108` conveyor label (see `references/reference_navigator_mcp_scope.md`)
+- *Source: Apurba May 20*
+
+#### 6. Weekly customer-status newsletter
+
+- Cadence: weekly
+- Draft and send
+- *Source: Apurba May 20*
+
+---
+
+### Quadrant 4 — Low / Low (background, time-permitting)
+
+#### 7. Navigator onboarding doc (internal non-technical)
+- Recreated version
+- Apurba: "leave that with me" — not Travis's to drive right now
+
+#### 8. Navigator strategy document (internal technical)
+- Owner TBD — confirm
+
+#### 9. Vendor list document
+- Can wait until after Thursday next week
+
+#### 10. Use-case identification (robot upsell, others)
+- Surface to team when patterns emerge
+
+#### 11. Project Jetstream — Navigator internal rollout
+- Continuation work
+
+---
+
+## Cross-cutting / dependencies
+
+- **Avinash + Anish conversations needed (Tue May 26):**
+  - Caglia engineering coordination
+  - Claude account situation — Travis2 user or sales-account phone-verification fix (Travis is out of credits until Friday per May 21 meeting)
+  - Libra Chat admin access (per Apurba's pointer)
+- **Sid's MCP skills documentation:** pasted in Google Meet chat — extract and feed into Grafana assistant as A/B context
+- **Fresno trip:** rescheduling, want Corey on-site next time. Apurba committed to regular visits.
+
+---
+
+## External / personal track (low priority but live)
+
+| Status | Item |
+|---|---|
+| DONE Mon May 18 | LinkedIn Navigator launch post — posted |
+| DONE Mon May 18 | Mylinda follow-up — sent |
+| OVERDUE | Galguera mezcal case study — readability review (due 2026-05-18) |
+| PENDING INFO | Project House Cleanup — Travis to share more |
+| OPEN | Wayo loop check-in |
+| OPEN | Conexum / Grafana chat thread |
+
+---
+
+## What I need from you next (to finish enrichment + daily breakdown)
+
+### 1. Link drop into `links.md` (top priorities)
+
+To enrich each task with actual state, I most need:
+
+- Grafana chat eval spreadsheet (prompts + pass/fail)
+- Grafana chat shareable links (your light-yellow attempts so far)
+- Caglia JIRA epics + Confluence pages
+- Belt lacing S3 bucket path
+- Central compute draft
+- Sid's MCP skills documentation (the Google Meet chat paste)
+- Navigator internal rollout / Jetstream artifacts
+- Project House Cleanup thread
+
+### 2. Notion question
+
+You mentioned organizing "based on Apurba's meeting and Notion." Two options:
+
+- **(a)** Give me your Loose Tasks DB link — I'll read what's already there and merge, then mirror this map into Notion at the end
+- **(b)** Keep planning here in markdown; I write to Notion only when you say so
+
+### 3. House Cleanup context — share when you've got it
+
+---
+
+## What happens after enrichment
+
+I produce a daily breakdown (Thu PM → Fri → Tue → Wed) with concrete deliverables per day, ending Wed May 27 with the data review locked and prepped.

--- a/connections.md
+++ b/connections.md
@@ -1,17 +1,50 @@
 # Connections
 
-Registry of every system your AIOS can reach. Filled by `/onboard` from Q4-Q7 answers; expanded over time as you wire new tools. `/audit` checks this file for domain coverage and freshness.
+Registry of every system the AIOS can reach. Filled by `/onboard` from Q4-Q7 answers; expanded over time as new tools get wired. `/audit` checks this file for domain coverage and freshness.
+
+## Substrates
+
+Two MCP routers carry most of the AIOS's reach. Per-toolkit rows below run through one of these:
+
+| Substrate | What it exposes | Umbrella reference |
+|---|---|---|
+| **Composio** (`mcp__mcp-router__COMPOSIO_*`) | Gmail, Google Calendar, Google Drive, Google Docs, Google Sheets, Granola, Fireflies — plus other connected-but-not-yet-exercised toolkits (Notion, GitHub, Exa, Firecrawl, LinkedIn read, Supabase, etc.) | `references/composio-mcp.md` |
+| **Atlassian** (`mcp__claude_ai_Atlassian__*`) | Jira + Confluence on `everestlabs.atlassian.net` | `references/jira-mcp.md` (covers both) |
+
+## Per-tool registry
 
 | # | Domain | Tool | Mechanism | Auth | Last checked |
 |---|---|---|---|---|---|
-| 1 | Revenue / Financials | _filled by /onboard_ | not yet connected | — | — |
-| 2 | Customer interactions | _filled by /onboard_ | not yet connected | — | — |
-| 3 | Calendar | _filled by /onboard_ | not yet connected | — | — |
-| 4 | Communication | _filled by /onboard_ | not yet connected | — | — |
-| 5 | Project / task tracking | _filled by /onboard_ | not yet connected | — | — |
-| 6 | Meeting intelligence | _filled by /onboard_ | not yet connected | — | — |
-| 7 | Knowledge / files | _filled by /onboard_ | not yet connected | — | — |
+| 1 | Revenue / Financials | **Customer Deployment Dashboard** (Google Sheet, ID `1gMk0GkQqDjQ6MINHCkFHA-rco6ZddxbvlhbXSoNXz8M`) via Drive MCP | `mcp` | Composio (Drive `travis-everestlabs`) | 2026-05-19 |
+| 1b | Revenue / Financials | Salesforce (accounts, deals, customer stage) | not yet connected | — | — |
+| 2 | Customer interactions | Gmail (travis@everestlabs.ai) | `mcp` | Composio (Gmail `travis-everestlabs`) | 2026-05-19 |
+| 2b | Customer interactions | Zoom + customer texting channels | not yet connected | — | — |
+| 3 | Calendar | Google Calendar (work + personal) | `mcp` | Composio (GoogleCalendar `travis-everestlabs` default, `travis-personal`) | 2026-05-19 |
+| 4 | Communication | Flock (internal team — Slack-equivalent at Everest) | not yet connected | — | — |
+| 4b | Communication | Gmail (travispeng@gmail.com) | `mcp` | Composio (Gmail `travis-personal-gmail`) | 2026-05-19 |
+| 4c | Communication | LinkedIn DMs | not yet connected | — | — |
+| 5 | Project / task tracking | JIRA (Everest cloud `everestlabs.atlassian.net`, 13 projects — POC, NAV, L2, ENG, CORE, CI, PI, PB, POI, RR, DPUC, PART, WT) | `mcp` | Atlassian (claude.ai connector, cloudId `e830597d-ffd6-4aed-a34b-e0bbb574db04`) | 2026-05-19 |
+| 5b | Project / task tracking | Confluence (same site, same connector — read/write scopes) | `mcp` (available, not yet exercised) | Atlassian (claude.ai connector) | 2026-05-19 |
+| 6 | Meeting intelligence | Granola (primary, Everest meetings) | `mcp` | Composio (granola_mcp `gainly-micro`) | 2026-05-19 |
+| 6b | Meeting intelligence | Fireflies (some Everest + personal recordings) — Everest channel `6a0c1cec7610454b44024df2` | `mcp` | Composio (fireflies `relink-spacer`) | 2026-05-19 |
+| 7 | Knowledge / files | Google Drive (work + personal) | `mcp` | Composio (GoogleDrive `travis-everestlabs` default, `travis-personal`; Docs same aliases) | 2026-05-19 |
 
 **Mechanism options:** `mcp` (MCP server), `script` (Python/Bash hitting an API, in `scripts/`), `export` (CSV/JSON dump pipeline), `key+ref` (`.env` key + `references/{tool}-api.md` guide), `not yet connected`.
 
-When you wire a new tool, also save `references/{tool}-api.md` capturing endpoints, auth flow, and common queries — researched-once-saved-forever.
+When a new tool is wired, also save `references/{tool}-mcp.md` (or `{tool}-api.md` for key+ref tools) capturing endpoints, auth flow, and common queries — researched-once-saved-forever.
+
+**Reference docs in place** (under `references/`):
+- `composio-mcp.md` — **umbrella substrate**: account-alias system, search-then-execute pattern, oversized-response handling, default-account-mismatch table, **per-toolkit notes for Gmail / Calendar / Drive / Docs / Sheets** (these are Composio toolkits, not separate MCPs — folded into the umbrella).
+- `granola-mcp.md` — meeting intelligence (primary). Standalone because Granola's concepts (query / list / get / transcript) are distinct.
+- `fireflies-mcp.md` — meeting intelligence (secondary, Everest channel). Standalone because Fireflies' channel model + AskFred are distinct.
+- `jira-mcp.md` — project / task tracking (Everest cloud; also covers Confluence availability via the same connector). Standalone because Atlassian is a different MCP substrate.
+- `3ms-framework.md` — operator brain (shipped in kit, read-only)
+
+**Open / known gaps.**
+
+1. **Salesforce** — no MCP yet. Composio doesn't offer Salesforce in Travis's current tool list. Options: build a script with the Salesforce REST API + `references/salesforce-api.md`, or wait for a future Composio integration. Important — Salesforce is the system of record for deals + customer hierarchy ([[salesforce]] in the wiki).
+2. **Flock** — internal company messaging, no MCP. The bulk of internal team communication lives here and isn't yet queryable.
+3. **Confluence** — connector is wired (Atlassian MCP with read/write scopes), but no reference doc written yet. Worth a future `/level-up` since SE-team-owned per-MRF data lives there.
+4. **Google account default mismatch.** Calendar + Drive default to `travis-everestlabs`. Gmail defaults to `travis-personal-gmail`. **Always pass the `account` alias explicitly** — the inconsistency burns time when forgotten.
+
+**JIRA adoption — partial (2026-05-19).** Engineering is on JIRA (POC, NAV, L2, ENG projects have active churn; Travis is assignee on POC-6, POC-14, POC-19 and others). But the POC team / customer-facing structure Apurba designed on May 13 — customer-feature epics with `is blocked by` links to engineering issues — is **not yet rolled out**. Travis has to teach the structure and onboard the rest of the POC team. Until that's done, JQL searches across customer features will be incomplete and dependency walks will hit gaps. Wiki's [[everest-labs]] page should reflect this nuance on next wiki pass (currently overstates the "not active" claim).

--- a/context/about-business.md
+++ b/context/about-business.md
@@ -1,0 +1,21 @@
+# About the business — Everest Labs
+
+**What it sells.** Everest Labs sells an AI software + robotics platform to recycling plants and Material Recovery Facilities (MRFs). Camera-vision systems and robotic arms identify and sort recyclable materials so they don't end up in landfills. The platform (RecycleOS + the in-development **Navigator** product) provides operational data MRF operators use to optimize throughput and brands use to track sustainability claims. Commercial models: RaaS (robots-as-a-service) and CapEx. Deals are facility-by-facility; sales go through RSGs (Recycling Solutions Group quotes) and per-facility proposals.
+
+**ICP.** MRF operators (primary buyers — plant managers, ops directors). Secondary: consumer-goods brands and waste haulers who want supply-chain sustainability data.
+
+**Where deals and revenue live.**
+- **Salesforce** — system of record for accounts, customer type/stage, proposals; Gmail integration on account records.
+- **Customer Deployment Dashboard** (Google Sheet) — list of actively deployed lines/systems: https://docs.google.com/spreadsheets/d/1gMk0GkQqDjQ6MINHCkFHA-rco6ZddxbvlhbXSoNXz8M/edit?gid=0#gid=0
+- **Proposals** — currently scattered; Apurba is compiling RSG / Caglia / Circular Services proposals into one consolidated doc for Travis and Avinash.
+
+**The big bet right now: Navigator.** Navigator is Everest Labs' first agentic product — a platform that drives **action**, not just dashboards. Three buckets of action: (1) pinpointing operators toward something (alerts/alarms); (2) doing it on their behalf (automation, e.g., predictive maintenance, recipe switching for wet/dry days); (3) running simulations to improve performance. Core tech stack: vision AI on conveyor belts + parameterization + agentic actions on plant control systems. Grafana is the starting UI. MCP server wires data through. GA target: **July 2026**. Revenue from Navigator not expected until mid-2027.
+
+**Strategic frame** (Apurba's): the company is taking AI workflow tooling out of "desk jobs" (where coding agents, financial agents, consulting agents already exist) and applying it to industrial **continuous manufacturing** — a TAM ~2x discrete manufacturing. Conveyor belts now, pipes eventually. Few competitors operating at this intersection.
+
+**Active POCs (Travis's portfolio).**
+1. Caglia
+2. Republic OEE
+3. Circular Services (Sarasota) — still somewhat ill-defined
+4. Ecology one (proposal phase)
+5. Connections (planning phase)

--- a/context/about-me.md
+++ b/context/about-me.md
@@ -1,0 +1,5 @@
+# About Travis
+
+Travis Peng — Northeastern University student, Associate GTM Intern (Sales & Operations Strategy) at Everest Labs since January 2026. Based out of Everest Labs HQ in Fremont, CA. Email travis@everestlabs.ai. GitHub Coderman562. Personal site travispeng.com. Builder by instinct (engineering/coding background), now learning the commercial side of a hard-tech robotics company. Reports to Apurba; works alongside Garima (marketing/messaging), Dan, Sid, Anish, Avinash, Ted, Georgia, and the broader team.
+
+**Top pain right now:** chasing things down. Tracking own TODOs, tracking POC state across Caglia / Republic OEE / Circular Services, and surfacing info scattered across Salesforce, Google Drive, Flock, Granola, and individual share links. The "middle person" coordination load between engineering and customer for each Navigator feature is a related drain.

--- a/context/priorities.md
+++ b/context/priorities.md
@@ -1,0 +1,11 @@
+# 90-day priorities
+
+**Window:** mid-May 2026 → end of summer internship (~mid-August 2026).
+**Anchored to:** May 13 onboarding meeting with Apurba.
+**Overarching outcome:** be able to say at end of internship — *"I was on the launch team for Everest Labs' first agentic product (Navigator)"* — with breadth across customer engineering, GTM, and launch docs.
+
+1. **Own the Navigator POC rollouts.** Be the Navigator rollout guy across Caglia, Republic OEE, and Circular Services (Sarasota); plus ecology and Connections as they spin up. Per feature: scope with customer, coordinate engineering (Sid / Anish / Avinash / Ted), deploy, gather feedback, iterate. Track everything in JIRA — customer-facing feature epics with dependencies on engineering tickets. Apurba: *"don't let any balls drop."* Current sprint dev milestone: end of May.
+
+2. **Build the "What is Navigator" internal training artifact before July GA.** Turn the long onboarding doc into a 2-minute consumable artifact (video or animated PowerPoint) that paints Navigator without going "LLM pilled." Sequence: engineering team first, sales team in late summer. Target ready well before GA.
+
+3. **Design and run the external customer warming program for July GA.** Audience: ~30–40 existing robot customers (hardware already deployed, no shipping cost). Build the program: teaser video, walkthrough demo (group + 1:1 options), free month of Navigator wired to their robot data via MCP. Goal: real feedback from advanced users before GA, and seeding demand. Plan now, execute around GA.

--- a/decisions/log.md
+++ b/decisions/log.md
@@ -19,3 +19,139 @@ Append-only record of meaningful decisions and why they were made. `/level-up` P
 Keep it terse. Future-you will thank present-you for capturing the *why*, not just the *what*.
 
 ---
+
+## 2026-05-19 — `/level-up` run: Granola → Personal Brain wiki ingest workflow
+
+**Decision:** Ship `references/granola-mcp.md` as the prompt-only artifact for ingesting Granola meetings into the Personal Brain wiki. Autonomy L2 (Drafted) — Claude drafts the source page and touched updates; Travis reviews at two pause points per meeting in the interactive ingest loop.
+
+**Method (5-step Method pipeline):**
+
+- *Constraint*: doc-scatter — no unified access to Everest meeting context across Granola / Drive / Salesforce / Flock. Granola was the highest-leverage starting connector because 51 Everest meetings live there.
+- *EAD*: Automate. Eliminate rejected — meetings are already recorded and valuable. Delegate rejected — no other human bandwidth.
+- *Process map*: Trigger = backlog ingest or specific recall. Data source = 4 Granola MCP tools via Composio. Transformations = query → format → write raw → run wiki INGEST per `Personal Brain/CLAUDE.md` §4a. Decision points = which Granola tool, confidentiality, page-vs-mention, grouping. Destination = `Personal Brain/raw/meetings/` then `wiki/sources/`.
+- *Autonomy*: L2.
+- *KPI*: Bucket = less cost (Travis's time). Metric = time to recall meeting context — seconds via wiki query vs minutes hunting in Granola directly.
+
+**Machine:** Prompt-only (Boring-is-Beautiful option 1). Reference doc + an interactive ingest-loop prompt for a separate Claude chat to drive the wiki repo session-by-session.
+
+**Why:** Granola is the rawest source of Everest meeting context and the wiki schema's INGEST workflow was already designed for it. Pattern is reusable for Fireflies and any future meeting sources.
+
+**Alternatives considered:**
+1. Deterministic skill that fully automates ingest — rejected; too much judgment per source (confidentiality calls, page-vs-mention, conflict resolution).
+2. Skip the reference doc and just exercise tools ad-hoc — rejected; future agents would re-discover the same gotchas.
+3. Start with Calendar instead — rejected; Granola is closer to Travis's stated top pain (chasing things down).
+
+**Owner:** Travis.
+
+---
+
+## 2026-05-19 — `/level-up` run: Fireflies → Personal Brain wiki ingest workflow
+
+**Decision:** Ship `references/fireflies-mcp.md` as the prompt-only artifact for ingesting Fireflies meetings (Everest channel) into the wiki. Same L2 autonomy as Granola; the existing interactive ingest-loop prompt covers both sources.
+
+**Method (5-step Method pipeline):**
+
+- *Constraint*: 5 Everest-channel Fireflies meetings (Avinash data pipeline x2, JIRA Structure, Grafana/CADLIA Project Update, Grafana Assistant Evaluation) are siloed and not queryable from the wiki. Closes Everest coverage from 5/56 to 10/56 once ingested.
+- *EAD*: Automate. Same rejection logic as Granola.
+- *Process map*: Trigger = same as Granola. Data source = Composio Fireflies tools (`GET_TRANSCRIPT_BY_ID`, `GET_TRANSCRIPTS`, `CREATE_ASK_FRED_THREAD`). Transformations = list → client-side filter on `channels[0].id === "6a0c1cec7610454b44024df2"` → format speaker labels (named or anonymized) → write raw → run wiki INGEST. Decision points = same as Granola plus channel filter, auto-title overrides, null-sentences handling. Destination = same.
+- *Autonomy*: L2.
+- *KPI*: Bucket = less cost. Metric = coverage % (Everest meetings ingested / total across Granola + Fireflies).
+
+**Machine:** Prompt-only. Same Boring-is-Beautiful default; same reasoning.
+
+**Why:** Fireflies catches what Granola misses for Everest work (architecture + engineering meetings in May 2026). Without the parallel reference doc, agents re-derive the channel filter pattern, null-sentence handling, and auto-title problem on every session.
+
+**Alternatives considered:**
+1. Build a generic "meeting source" abstraction covering both Granola and Fireflies — rejected; the two APIs differ enough (channel model vs no channel, summary shape, speaker labeling) that the abstraction would leak immediately.
+2. Defer Fireflies until all Granola is ingested — rejected; Fireflies-only meetings on May 4 and May 15 are operationally important now (data pipeline, JIRA, Grafana).
+
+**Owner:** Travis.
+
+---
+
+## 2026-05-19 — `/level-up` run: Google Calendar → AIOS query reference
+
+**Decision:** Ship `references/googlecalendar-mcp.md` as the prompt-only artifact for Google Calendar workflows. Autonomy L1 (Suggested) — Claude pulls calendar data, Travis decides what to do with it (no automation runs Calendar in the background yet).
+
+**Method (5-step pipeline):**
+- *Constraint*: pre-meeting context rebuild costs minutes per meeting. Without programmatic Calendar access, Travis manually opens Calendar / Granola / wiki for each meeting.
+- *EAD*: Automate.
+- *Process map*: Trigger = morning brief or 30-min-before-meeting. Data source = Composio Google Calendar tools across two accounts (`travis-everestlabs` default, `travis-personal` secondary). Transformations = list events → extract attendees → enrich from wiki. Decisions = which account, single vs all-calendars query, recurring vs instances. Destination = pre-meeting brief (output only; no wiki write).
+- *Autonomy*: L1.
+- *KPI*: Bucket = less cost. Metric = time-to-context-readiness before a meeting.
+
+**Machine:** Prompt-only. Reference doc with multi-account flagged (default `travis-everestlabs` — opposite of Gmail).
+
+**Why:** Calendar is foundational for the pre-meeting briefer, Calendar↔Granola cross-check, and week-ahead Everest meeting roll-ups. Cheap to wire; high-leverage downstream.
+
+**Alternatives considered:**
+1. Deterministic skill for the pre-meeting briefer — deferred; needs Calendar + wiki + Granola query orchestration that's better proven manually first.
+
+**Owner:** Travis.
+
+---
+
+## 2026-05-19 — `/level-up` run: Gmail → AIOS query reference
+
+**Decision:** Ship `references/gmail-mcp.md` as the prompt-only artifact for Gmail workflows. Autonomy L1.
+
+**Method (5-step pipeline):**
+- *Constraint*: email context is scattered across two accounts (work + personal). Travis manually searches for specific threads. Project Jetstream label already exists for the work account but isn't being queried programmatically.
+- *EAD*: Automate.
+- *Process map*: Trigger = catch-up scan, specific person lookup, or surname resolution. Data source = Composio Gmail tools (`travis-everestlabs` for work, `travis-personal-gmail` for personal). Transformations = query construction → metadata-first list → selective full hydration → base64url decode of body parts. Decisions = which account, `label_ids` vs `label:` in query, verbose vs metadata-only. Destination = wiki ingest (when email is the source) or context for other workflows.
+- *Autonomy*: L1.
+- *KPI*: Bucket = less cost. Metric = time-to-find-thread + surname/people-data fill rate against open wiki questions.
+
+**Machine:** Prompt-only. Reference doc with strong emphasis on the default-account gotcha (Gmail default is personal — opposite of Calendar/Drive).
+
+**Why:** Gmail surfaces Drive doc links from email threads (e.g., Apurba's May 13 "POC background materials" email — the entry point for proposal Drive IDs), produces surname resolutions cheaply, and the Project Jetstream label is a curated scoping mechanism that beats `subject:jetstream` queries.
+
+**Alternatives considered:**
+1. Build a deterministic skill that auto-classifies inbox emails into wiki-actionable buckets — deferred; needs human-in-the-loop on classification calls until the pattern is proven.
+
+**Owner:** Travis.
+
+---
+
+## 2026-05-19 — `/level-up` run: Google Drive → AIOS query reference
+
+**Decision:** Ship `references/googledrive-mcp.md` as the prompt-only artifact for Google Drive workflows. Autonomy L1.
+
+**Method (5-step pipeline):**
+- *Constraint*: doc-scatter — Customer Deployment Dashboard, POC proposals (Caglia/Republic/Circular), the onboarding doc Travis is writing — all in Drive without consolidation. Travis must remember each file's URL.
+- *EAD*: Automate.
+- *Process map*: Trigger = ingest a doc as a wiki source, pull deployment dashboard snapshot, or refresh proposal context. Data source = Composio Drive tools across two accounts (`travis-everestlabs` default; `travis-personal` rarely). Transformations = JQL-style search → metadata check → export-as-format (markdown for Docs, CSV for Sheets, plain text for Slides). Decisions = native download vs Workspace export, mimeType targeting, sharedWithMe vs owned. Destination = `Personal Brain/raw/proposals/` and `raw/data/` parallel to `raw/meetings/`, then wiki INGEST.
+- *Autonomy*: L1.
+- *KPI*: Bucket = less cost. Metric = number of doc-driven facts in the wiki / total Drive sources referenced in conversation.
+
+**Machine:** Prompt-only. Reference doc with known-resources table (Customer Deployment Dashboard ID, etc.) and use-case-specific query patterns.
+
+**Why:** Drive is the data layer below most wiki content. Without programmatic access, doc-scatter persists.
+
+**Alternatives considered:**
+1. Build a "Drive folder watcher" that auto-ingests new POC docs into the wiki — deferred; requires defining what "POC doc" means programmatically.
+
+**Owner:** Travis.
+
+---
+
+## 2026-05-19 — `/level-up` run: JIRA (Atlassian) → AIOS query reference
+
+**Decision:** Ship `references/jira-mcp.md` as the prompt-only artifact for JIRA workflows. Autonomy L1. **Includes a wiki-correction note** because the data contradicts a prior wiki claim ("team not yet active on JIRA").
+
+**Method (5-step pipeline):**
+- *Constraint*: POC dependency tracking and weekly status briefing both require querying JIRA. Wiki's prior claim that the team wasn't on JIRA was wrong — POC project alone has 34+ issues with Travis as assignee on POC-6, POC-14, POC-19; active churn within the last 24 hours.
+- *EAD*: Automate.
+- *Process map*: Trigger = weekly POC status, pre-meeting brief, "what did Apurba assign me," surfacing engineering dependencies for a customer-feature. Data source = Atlassian MCP (`mcp__claude_ai_Atlassian__*`) — not Composio — with constant `cloudId: "e830597d-ffd6-4aed-a34b-e0bbb574db04"`. Transformations = narrow JQL query → markdown response → field extraction. Decisions = which project to scope to, `responseContentFormat: "markdown"` vs `"adf"`, when to follow `issuelinks` chains. Destination = status brief output or wiki cross-reference notes on customer pages.
+- *Autonomy*: L1.
+- *KPI*: Bucket = less cost. Metric = time to resolve "why isn't this feature ready" via dependency walk.
+
+**Machine:** Prompt-only. Reference doc includes the 13 Jira projects, the load-bearing four (POC, NAV, L2, ENG), and load-bearing JQL patterns. Also flags that the same Atlassian connector exposes Confluence with read/write — deserves its own future `/level-up` for `references/confluence-mcp.md`.
+
+**Why:** JIRA is the operational truth layer below the wiki. Wiki captures why; JIRA captures what's open and what's blocking. Combined they answer the questions Apurba and the team are most likely to ask.
+
+**Alternatives considered:**
+1. Use Composio's Atlassian integration instead of Anthropic's claude.ai Atlassian connector — rejected; the claude.ai Atlassian connector is already wired with both Jira and Confluence scopes on Travis's account.
+2. Defer JIRA until the team is more active — rejected; the team is already active. The wiki was stale on this point.
+
+**Owner:** Travis.

--- a/links.md
+++ b/links.md
@@ -1,0 +1,115 @@
+# Links Registry
+
+> Drop links into the **Inbox** at the top. I (Claude) will investigate (fetch / read what I can) and route to the right category. Categories cover the recurring buckets — add new ones as needed.
+
+---
+
+## Inbox (unsorted — paste freely)
+
+<!-- paste here, I'll triage -->
+
+---
+
+## Navigator (product, strategy, marketing)
+
+### Strategy / positioning
+-
+
+### Onboarding & training material (internal non-technical, internal technical)
+-
+
+### Marketing & GTM
+- LinkedIn announcement post (2026-05-18):
+
+### Internal rollout (Project Jetstream)
+-
+
+---
+
+## POCs
+
+### Caglia (Fresno)
+-
+
+### Republic Services — Indianapolis (OEE)
+-
+
+### Republic Services — Tucson
+-
+
+### Recology Sonoma
+-
+
+### Circular Services — Sarasota
+-
+
+### Cleanaway Coolaroo
+-
+
+### Ecology
+-
+
+### Connections (upcoming)
+-
+
+---
+
+## Engineering surfaces
+
+### Grafana (dashboards + chat + LLM plugin)
+- Grafana Cloud Everlabs instance:
+- Grafana chat eval spreadsheet (prompts + pass/fail):
+- Grafana chat shareable links (per-issue):
+
+### JIRA / Confluence — `everestlabs.atlassian.net`
+- Caglia epics:
+- Navigator project board:
+- Confluence — RSG Indianapolis site survey:
+
+### Looker
+-
+
+### Navigator MCP — endpoint, docs, scope notes
+-
+
+### S3 buckets (belt video, raw data, etc.)
+- Belt video bucket:
+
+---
+
+## Belt analysis (utilization, loading, lacing)
+-
+
+---
+
+## Central Compute
+- Travis's draft:
+- Supporting docs:
+
+---
+
+## Evaluation alternatives (Grafana chat replacements)
+
+- **Libra Chat** —
+- **Open Web UI** —
+- **Onyx** —
+
+---
+
+## External references / vendors / docs
+
+- Anthropic skills / MCP docs (Sid's drop in Google Meet chat):
+- PromptQL / Hasura:
+
+---
+
+## People / org
+-
+
+---
+
+## Personal track
+
+- Galguera mezcal case study:
+- Project House Cleanup:
+- Wayo:

--- a/references/aios-task-system.md
+++ b/references/aios-task-system.md
@@ -1,0 +1,294 @@
+# AIOS Task System
+
+The operating manual for Travis's task + project management. A fresh chat session reading this file, querying Notion, and reading the current week's plan should have everything needed to work on any open task without further context.
+
+## Purpose
+
+This system is designed around one principle: **cold-start function**.
+
+A new session (no prior context) must be able to:
+1. Read this file → understand the system
+2. Query the Notion Tasks DB → see what's open
+3. Follow a Task's `Project` relation → get surrounding context
+4. Follow a Task's `Related tasks` → see connected work
+5. Read the current week's plan in `weekly-plans/` → know *when* and *why* the task is scheduled
+6. Execute the work and update the Task's Status + Update log
+
+If a fresh session can't do this, the system has failed at its primary purpose.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────┐
+│  Source of truth — what the work IS + how to do it         │
+│                                                            │
+│  Notion: Projects DB ─── parent ───┐                       │
+│                                    ▼                       │
+│  Notion: Tasks DB ─────────────────┘                       │
+└────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────┐
+│  Source of truth — WHEN work is scheduled + WHY            │
+│                                                            │
+│  Repo: weekly-plans/{YYYY-MM-DD}.md                        │
+│  (one file per week, snapshot + append-only change log)    │
+└────────────────────────────────────────────────────────────┘
+
+┌────────────────────────────────────────────────────────────┐
+│  Operating manual + supporting files                       │
+│                                                            │
+│  references/aios-task-system.md  ← this file               │
+│  links.md                        ← link registry by project│
+└────────────────────────────────────────────────────────────┘
+```
+
+## Notion: Projects DB
+
+Container for workstreams that **live ≥1 month and have multiple related tasks**. Shorter / smaller workstreams are just tasks (optionally with a parent project).
+
+### Fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| Name | title | yes | Project name |
+| Status | select | yes | `Active` · `Parked` · `Done` · `Reevaluating` |
+| Parent project | relation → Projects (self) | optional | Max 2 levels of nesting. Top-level projects have none. |
+| Dependencies | relation → Projects (self) | optional | Cross-pillar sequencing (what must finish before this can move). Different from Parent (containment) vs Dependencies (sequencing). |
+
+### Page body template
+
+```markdown
+## Purpose
+One paragraph — why this project exists, what problem it solves, what success looks like at the end.
+
+## Scope
+- In: what this project covers
+- Out: what's intentionally NOT in scope
+
+## Definition of done
+Concrete completion criteria. Not "make Navigator better" — instead "all 5 Internal Rollout steps shipped + 3 internal stakeholders onboarded + first wave external touch sent"
+
+## Stakeholders
+Who's involved, what role, what they need from you, what you need from them
+
+## Sources
+References that informed or birthed this project. Meetings, docs, articles, conversations. Not load-bearing — background context only.
+
+## Open questions
+Unresolved issues blocking decisions; flagged so future-you (or a fresh chat) sees them surfaced
+
+## Decision log
+Append-only. Decisions about the project itself (scope, approach, choices).
+- YYYY-MM-DD: <what was decided>
+  Why: <reason>
+
+## Linked references
+External docs, dashboards, repos, slides
+```
+
+## Notion: Tasks DB
+
+Container for concrete work items. Consolidates what used to be Academic Calendar + Loose Tasks.
+
+### Fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| Name | title | yes | Concrete action |
+| Status | select | yes | `To-do` · `In progress` · `Blocked` · `Done` · `Deferred` |
+| Project | relation → Projects | optional | Parent workstream. Hierarchy / pillar is inferred by following the Project's Parent chain. |
+| Deadline | date (no time) | optional | Only set when a real deadline exists. Never invent. |
+| Due Time | rich_text | optional | Separate from Deadline because Notion's datetime field breaks calendar view rendering. `8am`, `11:59pm`. |
+| Type | select | optional | `Deep work` · `Quick`. Deep work = >30 min; Quick = <30 min. |
+| Context links | URL list | optional | Direct refs the task needs (visible on calendar view for quick access) |
+| Related tasks | relation → Tasks (self) | optional | Captures task-to-task relationships ONCE. Notion auto-mirrors. Use for "blocks", "informs", "shares dependency on X" — prose semantics in body. |
+
+### Page body template
+
+```markdown
+## Goal
+One sentence — what done looks like for THIS task.
+
+## Context
+Relevant background a fresh chat needs to do this task without re-reading the whole project. Why this matters now.
+
+## Steps (optional, for non-trivial)
+Brief outline. Skip if the task is simple.
+
+## Blocked by
+Only if Status=Blocked. What's blocking, when it should clear.
+
+## References
+Inline links — docs, meeting notes, prior decisions.
+
+## Update log
+Append-only.
+- YYYY-MM-DD HH:MM: <what changed / what was done>
+```
+
+## Repo: weekly-plans/
+
+One markdown file per week. Captures the planning *rationale* — the layer of information that's about scheduling decisions, not about the work itself.
+
+### File naming
+`weekly-plans/{YYYY-MM-DD}.md` where the date is the Monday of the week.
+
+### File shape
+
+```markdown
+# Week of {Monday date}
+
+## Anchors (locked dates)
+Calendar items + deadlines that shape the week.
+
+## Plan (snapshot — written by /plan-my-week)
+
+### {Weekday} {Month} {Day}
+- {Task name}  [link to Notion task]
+  Why this slot: ...
+
+(repeat per day)
+
+## Reasoning / context that didn't fit elsewhere
+Free-form. Week's center of gravity, load-bearing pieces, squeeze points.
+
+## Change log (append-only mid-week)
+- YYYY-MM-DD HH:MM: <what changed>
+  Why: <reason>
+```
+
+A fresh agent reads this file alongside the Notion Tasks DB to understand both *what* is on the plate today AND *why* it landed today.
+
+## Cold-start protocol
+
+The exact sequence a fresh agent runs to pick up Travis's TODO list:
+
+1. **Read this file** (`references/aios-task-system.md`) — understand the system.
+2. **Read the current week's plan file** (`weekly-plans/{this Monday}.md`) — see what's scheduled today + this week's anchors + reasoning.
+3. **Query Notion Tasks DB** — filter `Status` in `{To-do, In progress, Blocked}` AND `Deadline ≤ today + 7 days` (or as needed). Surface what's open.
+4. **For each task of interest**:
+   - Read task body — Goal, Context, Steps
+   - Follow `Project` relation → read project body — Purpose, Scope, DoD, Stakeholders, Sources, Open questions, Decision log
+   - Follow `Related tasks` if any — see connected work
+   - Follow `Context links` — direct references
+5. **Cross-reference week plan** — confirm scheduling rationale ("why is this on Tuesday")
+6. **Act**. When done, update task Status + append to task body's Update log. If the scheduling changes, append to the current week plan's Change log.
+
+## Conventions
+
+### Project vs task
+- **Project**: workstream that lives ≥1 month AND has multiple related tasks under it
+- **Task**: concrete action item (or a short-lived multi-step deliverable)
+- Examples that ARE projects: Caglia, Navigator, House Cleanup, Family Finances, NEU subjects
+- Examples that are NOT projects (tasks instead): Central Compute certification work, Newsletter w/ Makenna, Vendor list, Profile cluster
+
+When in doubt: smaller and shorter → task. Bigger and longer → project.
+
+### Parent project depth
+Max 2 levels of nesting. Top-level → sub-project. No deeper.
+
+- Top-level: `Everest`, `Career`, `Family`, `Personal`, `Academic`, `Admin`
+- Sub-projects: nest under one top-level (e.g., `Caglia` parent=`Everest`)
+
+If a 3rd level feels needed, the structure is wrong. Either:
+- Flatten — the deepest item becomes a sub-project under the top-level
+- Or break the middle level into multiple sibling sub-projects
+
+### Subjects (when school active)
+- "Northeastern" is **not** a separate project layer. NEU subjects (ENTR2303, INMI0300, etc.) are sub-projects directly under `Academic`.
+- Class metadata (professor, room, schedule) lives in the subject's page body, not in a separate Subjects DB.
+
+### Deadlines
+- Never invent. Only set when Travis named a date or one is externally imposed.
+- For things that feel like they need a deadline but don't have one: surface that as a question; don't bake one in.
+
+### Type values
+- `Deep work` = anything >30 min
+- `Quick` = anything <30 min
+- That's it. No prep/errand/group distinctions.
+
+### Decision log vs Schedule log
+Two different "decision" layers, intentionally separate:
+- **Project body's Decision log** = decisions about *the work itself* (scope, approach, choices about how to do it)
+- **Weekly plan's Change log** = decisions about *when to do it* (timing, deferral, sequencing)
+
+### Recurring tasks
+Recurring projects (e.g., belt-lacing daily, weekly newsletter) spawn fresh dated tasks each occurrence rather than maintaining one persistent task with reset Status. Better audit trail.
+
+## Project taxonomy (initial state)
+
+### Top-level projects
+- `Everest`
+- `Career`
+- `Family`
+- `Personal`
+- `Academic`
+- `Admin`
+
+### Sub-projects (as of system creation)
+- Under Everest: `Caglia`, `Navigator`
+- Under Family: `House Cleanup`, `Family Finances`
+- Under Personal: `Personal Enrichment`
+- Under Academic (NEU subjects, Spring 2026): `ENTR2303: Marketing for Startups`, `PHIL3343: Existentialism`, `ACCT1201: Accounting`, `ECON1116: Microecon`, `Everest Labs (New Venture Development)`, `INMI0300`
+
+The taxonomy is dynamic. Projects come and go — add or archive as workstreams evolve.
+
+## Migration approach (from old system)
+
+This system replaces the old Academic Calendar + Loose Tasks + Subjects DBs. Migration is **organic, not bulk**:
+
+1. New tasks get created directly in the new Tasks DB.
+2. Old items get migrated by hand when they become relevant — they're either re-created with their new project context OR they're stale enough to drop entirely.
+3. Old DBs (Academic Calendar, Loose Tasks, Subjects) stay alive until they're empty of anything load-bearing, then archived.
+4. Galguera, LinkedIn post Sales/Ops → GTM = both already Done — closure happens in old DB as cleanup, no migration needed.
+
+No bulk import. Quality over completeness.
+
+## What this system intentionally does NOT have
+
+- **No "future container DBs"** placeholder for hypothetical extension. If a new entity type emerges (e.g., Clubs), it lives as a project in Projects DB.
+- **No Schedule Log DB**. Planning rationale lives in `weekly-plans/{YYYY-MM-DD}.md` files in this repo, not in Notion.
+- **No Type=Subtask**. Subtasks are handled by either making a task more complex (extra detail in body) or breaking it into multiple peer tasks. Self-relation on Tasks isn't a Parent-Child hierarchy — it's a Related-task relation.
+- **No Owner field**. Travis is the implicit owner. Rare exceptions (external owner) live in the task body's Context.
+- **No Tags field**. Cross-cutting categorization that doesn't fit Pillar-via-Project goes in task or project body prose.
+- **No Pillar/Sub-pillar enum field**. Pillars ARE the top-level projects. Adding a new pillar = adding a new top-level project, not changing the schema.
+
+These omissions are intentional. They keep the system small and lived-in. Add back only when a real, recurring need surfaces.
+
+## Open / TBD
+
+- **Backpacking Club** — currently misfiled in Subjects DB. Wind-down workstream. Needs to be created as a sub-project (parent TBD: Career? Personal?). Travis to confirm placement.
+- **BigScholars** — also misfiled in Subjects DB. Parked workstream. Will be reevaluated. When unparked, becomes a top-level project (`BigScholars`) or sub-project under Career.
+- **Fall 2025 NEU subjects** — not in Subjects DB. Travis to name if he wants them captured for historical purposes.
+- **Notion DB IDs** — to be filled in after Projects DB and Tasks DB are created in Notion.
+
+## Notion DB IDs
+
+- **Projects DB** (`Projects`): `3690c75c-46b3-81ed-ae3a-eeb3be8d1303` — lives inside `Life Hub` page (`8280c75c-46b3-8268-8b42-01cd65b1f230`)
+- **Tasks DB** (`Life Calendar`): `bfc0c75c-46b3-837b-9676-01cbead97b7d` — lives at workspace top-level
+
+## Initial Project rows (created 2026-05-22)
+
+### Top-level
+- **Everest** 🏔️ — `3690c75c-46b3-81df-ad1d-d593f664365b`
+- **Career** 💼 — `3690c75c-46b3-81fb-8bcf-d31a42dcea71`
+- **Family** 👨‍👩‍👧 — `3690c75c-46b3-8124-97ec-edf7b2b1db9d`
+- **Personal** 🌿 — `3690c75c-46b3-817d-9644-e4a11f1d7b36`
+- **Academic** 🎓 — `3690c75c-46b3-8138-8c65-e03243cbaf8d`
+- **Admin** 🗂️ — `3690c75c-46b3-81a2-888e-f61b56cb5a27`
+
+### Sub-projects
+- **Caglia** 🏭 — `3690c75c-46b3-81f2-922b-c2193a6fcb89` (parent: Everest)
+- **Navigator** 🧭 — `3690c75c-46b3-8118-a02b-f5c4f120edbf` (parent: Everest)
+- **House Cleanup** 🏡 — `3690c75c-46b3-8103-a049-d973c243effd` (parent: Family)
+- **Family Finances** 💰 — `3690c75c-46b3-8191-a31a-c1be78806dec` (parent: Family)
+- **Personal Enrichment** 📚 — `3690c75c-46b3-81d7-b6d9-fb970dd90e39` (parent: Personal)
+- **ENTR2303: Marketing for Startups** 📈 — `3690c75c-46b3-814a-9a9b-d3cdaff8d287` (parent: Academic, Status: Done)
+- **PHIL3343: Existentialism** 🕯️ — `3690c75c-46b3-81d0-a9be-dea87fc7a538` (parent: Academic, Status: Done)
+- **ACCT1201: Accounting** 🧾 — `3690c75c-46b3-8100-a235-cec64b9a30df` (parent: Academic, Status: Done)
+- **ECON1116: Microecon** ⚰️ — `3690c75c-46b3-81bd-9549-c596aa13a1ac` (parent: Academic, Status: Done)
+- **INMI0300** 🔬 — `3690c75c-46b3-81a9-afea-e9af2acf2a81` (parent: Academic, Status: Reevaluating)
+
+---
+
+*This file is the cold-start handshake. Keep it accurate. When schema or convention changes, update this file in the same commit.*

--- a/references/composio-mcp.md
+++ b/references/composio-mcp.md
@@ -1,0 +1,297 @@
+---
+bike-method-phase: 1  # Phase 1 — Training wheels. Run manually first.
+three-ms-attribution: |
+  Adapted from The Three Ms of AI™ © 2026 Nate Herk.
+---
+
+# Composio MCP — umbrella reference for the AIOS
+
+Composio is the **substrate** that exposes most of the AIOS's toolkits — not a domain-specific connection in its own right. This file is the canonical reference for the patterns shared across every Composio-backed toolkit, so per-tool reference docs don't have to repeat them.
+
+If you're working with a specific service (Gmail / Calendar / Drive / Docs / Granola / Fireflies), read this **and** the per-tool reference. They split the work: umbrella concepts live here; service-specific gotchas live in the per-tool doc.
+
+## What Composio is
+
+A tool-router that wraps many third-party APIs behind a unified MCP interface (`mcp__mcp-router__COMPOSIO_*`). Auth is managed centrally; each underlying service is a "toolkit" with its own slugs (e.g. `gmail`, `googlecalendar`, `googledrive`, `granola_mcp`, `fireflies`). One Composio session can address many toolkits in parallel.
+
+## Active toolkits at Everest
+
+Confirmed wired to Travis's Composio account:
+
+| Toolkit slug | What it covers | Reference |
+|---|---|---|
+| `gmail` | Gmail (read + write) | "Per-toolkit notes" below |
+| `googlecalendar` | Google Calendar (read primarily) | "Per-toolkit notes" below |
+| `googledrive` | Google Drive files (read + export) | "Per-toolkit notes" below |
+| `googledocs` | Google Docs (plaintext + structured) | "Per-toolkit notes" below |
+| `googlesheets` | Google Sheets — export via Drive's export tool | "Per-toolkit notes" below |
+| `notion` | Notion pages + databases (workspace "Travis's Notion") | "Per-toolkit notes" below |
+| `granola_mcp` | Granola meeting notes + transcripts | `granola-mcp.md` (standalone — distinct concepts) |
+| `fireflies` | Fireflies transcripts | `fireflies-mcp.md` (standalone — distinct concepts) |
+
+Other connected toolkits Travis has authenticated but the AIOS hasn't actively used yet: `apify`, `deepgram`, `exa`, `firecrawl`, `github`, `gladia`, `google_maps`, `linkedin`, `mem0`, `strava`, `supabase`, `supadata`, `youtube`. Prefer these over external API integrations when the use case maps.
+
+---
+
+## Account-alias system
+
+Composio supports **multiple authenticated accounts per toolkit**. Each is referenced by an alias (e.g. `travis-everestlabs`, `travis-personal`) or an opaque ID (e.g. `gmail_weakly-taa`). Pass `account: "<alias>"` on every `MULTI_EXECUTE_TOOL` call.
+
+### Travis's account map (verified 2026-05-19)
+
+| Toolkit | Default | Other |
+|---|---|---|
+| `gmail` | **`travis-personal-gmail`** (travispeng@gmail.com, ~66k msgs) | `travis-everestlabs` (travis@everestlabs.ai, ~659 msgs) |
+| `googlecalendar` | **`travis-everestlabs`** (work primary) | `travis-personal` (personal primary + AI Squads cohort) |
+| `googledrive` | **`travis-everestlabs`** (workspace `everestlabs.ai`) | `travis-personal` (personal Google) |
+| `googledocs` | **`travis-everestlabs`** | `travis-personal` |
+| `granola_mcp` | single account | — |
+| `fireflies` | single account | — |
+
+**Cardinal gotcha — default mismatch.** Gmail defaults to **personal**. Calendar / Drive / Docs default to **work**. Forgetting this and omitting `account` is the #1 wasted call across the AIOS. Always pass the alias explicitly.
+
+### Managing accounts
+
+Use `COMPOSIO_MANAGE_CONNECTIONS` for:
+- `action: "list"` — list accounts for a toolkit (returns IDs, aliases, active status).
+- `action: "add"` — initiate OAuth for a new account (returns a redirect URL to give Travis).
+- `action: "rename"` — change an alias on an existing account.
+- `action: "remove"` — delete an account.
+
+After `add`, always follow with `COMPOSIO_WAIT_FOR_CONNECTIONS` to poll until the connection is `active` before executing tools.
+
+---
+
+## Cardinal workflow patterns
+
+### 1. Search-then-execute
+
+Composio's tool registry is huge — schemas aren't preloaded. The pattern is:
+
+1. `COMPOSIO_SEARCH_TOOLS` with one or more `use_case` queries. Returns the relevant tool slugs **and full schemas inline** for the matches.
+2. `COMPOSIO_MULTI_EXECUTE_TOOL` with `tool_slug` + `arguments` + optional `account`.
+
+Critical: SEARCH_TOOLS often returns **recommended plans** and **known pitfalls** for the chosen tool. Read them before executing — they catch known bugs (e.g. response wrappers, pagination quirks, scope errors). Don't skip.
+
+### 2. Multi-execute is parallel when independent
+
+`COMPOSIO_MULTI_EXECUTE_TOOL` takes a `tools` array. Tools in the array run in parallel **if logically independent** — no shared inputs, no ordering. If tool B needs B's output to use as input, do it as two sequential calls.
+
+Up to 50 tools per call. Batch aggressively when calling the same toolkit on different accounts (e.g. work + personal Gmail in one call).
+
+### 3. Session continuity
+
+`COMPOSIO_SEARCH_TOOLS` returns a `session.id` (e.g. `"lion"`). Pass it back as `session_id` on subsequent `MULTI_EXECUTE_TOOL` calls. Keeps the workflow correlated for telemetry and avoids re-discovery overhead.
+
+For a brand-new workflow: `session: { generate_id: true }` on first SEARCH_TOOLS, then reuse the returned ID.
+
+### 4. Oversized response handling
+
+When response data may be large, set `sync_response_to_workbench: true` on `MULTI_EXECUTE_TOOL`. Inline preview still shows, full data saved to `/mnt/files/mex/*.json`.
+
+For huge file processing:
+- `COMPOSIO_REMOTE_WORKBENCH` — run Python on the workbench (e.g. parse a saved JSON file).
+- `COMPOSIO_REMOTE_BASH_TOOL` — run bash on the workbench (e.g. `jq`, `rg`).
+
+Used when a Granola transcript or Gmail bulk pull would otherwise overflow inline.
+
+### 5. Schema discovery for one named tool
+
+`COMPOSIO_GET_TOOL_SCHEMAS` with `tool_slugs: [...]`. Use when you already know the slug but need the parameter schema without re-running a SEARCH_TOOLS query.
+
+---
+
+## Critical gotchas
+
+- **Don't omit `account` on multi-account toolkits.** Default isn't always work. See the cardinal-gotcha table above.
+- **Don't invent toolkit slugs.** Always use exact slugs returned by `SEARCH_TOOLS`. Inventing a slug fails with `InputValidationError`.
+- **Search before manage.** If you're considering `COMPOSIO_MANAGE_CONNECTIONS` to add a new account, run `SEARCH_TOOLS` first — the toolkit may already be connected.
+- **`account_selection: "required"`** on the response means the toolkit has multiple accounts and you MUST pass `account`. Failing to do so will error.
+- **Response shape varies per tool.** Don't assume `data.items` or `data.messages` etc. — read the structure_info / data_preview that SEARCH_TOOLS returns.
+- **Pagination tokens are opaque.** Pass the exact `nextPageToken` string back. Don't construct, truncate, or guess.
+- **Rate limits are per-toolkit, not per-Composio.** Gmail / Drive have their own quotas. Apply exponential backoff on 429.
+- **Tool slugs vs internal IDs.** Account IDs look like `gmail_weakly-taa`; aliases look like `travis-everestlabs`. Both work as `account` value but aliases are stable across re-auth — prefer them.
+
+---
+
+## Per-toolkit notes
+
+Compact reference for the Composio-backed Google Workspace toolkits. (Granola and Fireflies have their own files because their concepts — channel IDs, AskFred, etc. — are distinct enough to warrant standalone docs.)
+
+### Gmail (`gmail`)
+
+- **Default account is personal** (`travis-personal-gmail`, ~66k messages). Always pass `account: "travis-everestlabs"` for work.
+- Query syntax: `from:`, `to:`, `subject:`, `label:`, `has:`, `is:`, `after:YYYY/MM/DD`, `before:YYYY/MM/DD`, AND/OR/NOT.
+- **`is:` vs `label:`** — `is:snoozed`, `is:unread`, `is:read`, `is:starred`, `is:important`. `label:` only for user-created labels.
+- **Project Jetstream label** ID: `Label_5261162509431064568`. Use `label_ids: ["Label_5261162509431064568"]` for clean Jetstream scope.
+- Inventory pass: `verbose: false`, `include_payload: false`. Hydrate selected hits via `GMAIL_FETCH_MESSAGE_BY_MESSAGE_ID` with `format: "full"`.
+- Bodies are base64url-encoded in `payload.parts`. Replace `-`→`+`, `_`→`/`, fix padding.
+- `messages: []` is a valid no-result state. `nextPageToken: ""` means end-of-pagination — don't loop.
+- Sort client-side by `internalDate` (ms epoch); results aren't sorted by recency.
+- Tools not yet exercised: `GMAIL_GET_ATTACHMENT`, `GMAIL_SEARCH_PEOPLE`, write ops (`SEND`, `REPLY_TO_THREAD`, `CREATE_LABEL`).
+
+### Google Calendar (`googlecalendar`)
+
+- **Default account is work** (`travis-everestlabs`). Opposite of Gmail.
+- Time ranges: RFC3339 with explicit offset. `"2026-05-19T00:00:00-07:00"` works; `"2026-05-19"` doesn't.
+- `singleEvents: true` + `orderBy: "startTime"` for clean chronological listing with recurring events expanded.
+- `GOOGLECALENDAR_GET_CURRENT_DATE_TIME` first when computing relative dates ("today", "this week") to avoid timezone drift.
+- `EVENTS_LIST_ALL_CALENDARS` unifies primary + holidays + group calendars; with `response_detail: "minimal"` events may live under `summary_view` (don't treat empty `events` as "no events").
+- All-day vs timed: all-day events have `start.date`; timed events have `start.dateTime`. Normalize before sorting.
+- Use case: **pre-meeting briefer**. Get current time → list next-24-hours events on `travis-everestlabs` → extract `attendees[].email` → look up people / customers in the Personal Brain wiki.
+- Use case: **Calendar ↔ Granola cross-check** — every event with `conferenceData` should produce a Granola recording. Missing recordings worth surfacing weekly.
+
+### Google Drive (`googledrive`)
+
+- **Default account is work** (`travis-everestlabs`, workspace `everestlabs.ai`).
+- `GOOGLEDRIVE_FIND_FILE` is the comprehensive search tool. Supports name, fullText, mimeType, modifiedTime, parents, owners, sharedWithMe, starred, trashed.
+- **`'root'`** for the root folder, not `'My Drive'`. `name = 'My Drive'` returns nothing.
+- Wildcards (`*`) **not supported**. Use `contains`.
+- Email searches: `"'user@example.com' in owners"` (or `in writers`, `in readers`). NOT `owner:user@example.com`.
+- Boolean fields explicit: `sharedWithMe = true`, `trashed = false`, `starred = true`.
+- `mimeType` decides the next step:
+  - `application/vnd.google-apps.document` → use `GOOGLEDOCS_*` tools or export via `EXPORT_GOOGLE_WORKSPACE_FILE`.
+  - `application/vnd.google-apps.spreadsheet` → export as CSV via `EXPORT_GOOGLE_WORKSPACE_FILE(mimeType: "text/csv")`.
+  - `application/vnd.google-apps.presentation` → export as PDF / text.
+  - `application/vnd.google-apps.folder` → use `LIST_CHILDREN_V2`.
+  - Anything else → blob; use `DOWNLOAD_FILE`.
+- Native Workspace files have `size: null` and `md5Checksum: null`. Classify by mimeType, not size.
+- `fullText contains` queries can't be combined with `orderBy`. Sort client-side.
+- `LIST_CHILDREN_V2` returns ChildReference objects (`id`, `childLink`, `selfLink`, `kind`) — not full File objects. Re-fetch via `GET_FILE_METADATA` or `FIND_FILE` for file-level details.
+
+**Known Drive resources for Travis:**
+- **Customer Deployment Dashboard** (Google Sheet): `1gMk0GkQqDjQ6MINHCkFHA-rco6ZddxbvlhbXSoNXz8M`. Export as CSV for snapshots in `Personal Brain/raw/data/`.
+- **POC proposals** (Caglia / Republic / Circular Services): Google Slides, links in Apurba's May 13 "POC background materials" email. Export as plain text or PDF for wiki ingest.
+
+### Google Docs (`googledocs`)
+
+- `GOOGLEDOCS_GET_DOCUMENT_PLAINTEXT` is the cleanest path for ingesting Doc content into the wiki. Configurable: `include_tables`, `include_footers`, `include_headers`, `include_footnotes`, `include_tabs_content`. Accepts either doc ID or full URL.
+- `GOOGLEDOCS_GET_DOCUMENT_BY_ID` for full Docs API JSON (styling, comments, structure).
+- `GOOGLEDOCS_SEARCH_DOCUMENTS` for Docs-only search (lighter weight than Drive's `FIND_FILE`).
+
+### Google Sheets (via Drive's export tool)
+
+- No dedicated `googlesheets` Composio toolkit slug at runtime — Sheets are reached through Drive.
+- Export as CSV: `GOOGLEDRIVE_EXPORT_GOOGLE_WORKSPACE_FILE` with `mimeType: "text/csv"` and the file's Drive ID.
+- For analytical data (Customer Deployment Dashboard, etc.), don't row-by-row ingest into the wiki. Snapshot, synthesize, cite the file ID and snapshot date.
+
+### Notion (`notion`)
+
+- **Single account** (`notion_letter-now`). Workspace = **"Travis's Notion"** (ID `5630c75c-46b3-81f5-9bda-000332fa0a04`). Owner travispeng@gmail.com. Composio integration connected 2026-04-06.
+- **Permission model gotcha (cardinal):** the Composio integration only sees pages and databases that have been **explicitly shared** with the bot user in Notion. If a search comes back empty for content Travis knows exists, the integration probably wasn't added to that page yet — open the page → Share → connect → add Composio. Empty results ≠ empty workspace.
+- **Search index lag.** Recently shared or created items may not appear in `NOTION_SEARCH_NOTION_PAGE` immediately. If a specific title search comes back empty, fall back to `query: ""` (empty) and filter client-side.
+
+**Current shape of Travis's Notion (May 2026 — primarily personal):**
+
+- ~6 databases, ~100+ pages (most are database rows).
+- **"Academic Calendar"** (`2e10c75c-46b3-81cd-8e14-f42de1435cce`, 🌦️ icon). Top-level. Properties: `Name` (title), `Type` (select: Assignment / Assessment / Reading / Event), `Subject` (relation → Academic Database), `Due Date`, `Due Time`, `Effort (Hours)`, `Grade` (number), `Index` (select A through E), `HW` / `HW2` (URL), `Description`, **`Done` (checkbox)**. Created Jan 7 2026.
+- **"Loose Tasks"** (`34f0c75c-46b3-817d-81f0-fe31e968ddb9`). Parent is a page (not workspace-level). Properties: `Name` (title), `Deadline` (date), `Notes` (rich_text), **`Status` (select: To-do / In progress / Blocked / Deferred / Done)**, `Thread` (select: Everest / Wayo / Big Scholars / Galguera / Cham / Stubbs / Naeem / TiECon / Ansara / Backpacking / LOV / Academic / Personal / Family / Self & spaces / Career / Admin / BigScholars). Created Apr 27 2026.
+- **Academic Database** (related to Academic Calendar via `Subject`). Holds per-class records with `Teacher`, `Reading`, `Link 1`, `HW`, `Class Notes (Active)`.
+- **No Everest content in Notion yet** (apart from one "Everest" thread tag in Loose Tasks for personal-side Everest items). Notion is currently a personal-leaning tool. If/when Travis brings work content over, this section should be updated.
+
+**Tool decision tree:**
+
+| If you need… | Use |
+|---|---|
+| Discover what's accessible (inventory) | `NOTION_SEARCH_NOTION_PAGE` with `query: ""` and `filter_value: "page"` or `"database"`. Paginate via `start_cursor` + `has_more`. |
+| Page metadata only (properties, parent, archived state) | `NOTION_RETRIEVE_PAGE` with `page_id`. **Page IDs only — database IDs fail.** |
+| Full readable page content as markdown | `NOTION_GET_PAGE_MARKDOWN` with `page_id`. One call; clean output. **Page IDs only.** |
+| Full hierarchical block tree | `NOTION_FETCH_ALL_BLOCK_CONTENTS` with `block_id` and `recursive: true`. Check `data.recursion_info.block_limit_reached` / `depth_limit_reached` to verify completeness. |
+| Database schema (property names + types) | `NOTION_FETCH_DATABASE` with `database_id`. Call this **before** querying — filter type keys must match the property's actual type. |
+| Query database rows | `NOTION_QUERY_DATABASE` (simple) or `NOTION_QUERY_DATABASE_WITH_FILTER` (filtered/sorted). |
+| Single row's properties | `NOTION_FETCH_ROW` with the row's page ID. |
+| Cross-cutting workspace search by content | `NOTION_FETCH_DATA` with `fetch_type: "pages" | "databases" | "all"`. Use when `SEARCH_NOTION_PAGE` returns nothing. |
+
+**Filter gotchas (databases):**
+
+- **Property names are case-sensitive.** `"status"` ≠ `"Status"`.
+- **Filter type key must match the schema type, not the property name.** A property named "Status" could be type `select` in one DB and type `status` (Notion's built-in workflow type) in another. Run `FETCH_DATABASE` first to confirm.
+- **`title` is reserved.** Always refers to the database's built-in primary title column, regardless of what you renamed it to in the UI.
+- **Select / status / multi-select option labels are case-sensitive**, including emoji prefixes. `"✅ Done"` ≠ `"Done"`. Mismatches return empty rather than erroring.
+- **System timestamps use simplified format:** `{"created_time": {"on_or_after": "2024-01-01"}}` — not the verbose `{"timestamp": "created_time", ...}` shape.
+- **Pagination cursors are opaque.** Pass `next_cursor` back exactly as returned. Stop on `has_more: false` or when cursor repeats.
+
+**Page IDs vs database IDs — common 400.** `NOTION_GET_PAGE_MARKDOWN` and `NOTION_RETRIEVE_PAGE` accept page IDs only. `NOTION_FETCH_DATABASE` and the query tools accept database IDs only. Mixing them is the most frequent error mode.
+
+**Saved queries — verified 2026-05-21:**
+
+These have been run end-to-end and confirmed to return data. Drop in as the `arguments` to `NOTION_QUERY_DATABASE_WITH_FILTER`.
+
+**1. All Academic Calendar items not done** (homework, assignments, readings, events — everything in the database without the `Done` checkbox ticked, oldest due first):
+
+```json
+{
+  "database_id": "2e10c75c-46b3-81cd-8e14-f42de1435cce",
+  "filter": { "property": "Done", "checkbox": { "equals": false } },
+  "sorts": [ { "property": "Due Date", "direction": "ascending" } ],
+  "page_size": 100
+}
+```
+
+If you want **only coursework** (exclude `Event` type), wrap with an `and`:
+
+```json
+{
+  "database_id": "2e10c75c-46b3-81cd-8e14-f42de1435cce",
+  "filter": {
+    "and": [
+      { "property": "Done", "checkbox": { "equals": false } },
+      {
+        "or": [
+          { "property": "Type", "select": { "equals": "Assignment" } },
+          { "property": "Type", "select": { "equals": "Assessment" } },
+          { "property": "Type", "select": { "equals": "Reading" } }
+        ]
+      }
+    ]
+  },
+  "sorts": [ { "property": "Due Date", "direction": "ascending" } ],
+  "page_size": 100
+}
+```
+
+**2. All Loose Tasks not done** (everything not in the `Done` Status — covers To-do / In progress / Blocked / Deferred — oldest deadline first):
+
+```json
+{
+  "database_id": "34f0c75c-46b3-817d-81f0-fe31e968ddb9",
+  "filter": { "property": "Status", "select": { "does_not_equal": "Done" } },
+  "sorts": [ { "property": "Deadline", "direction": "ascending" } ],
+  "page_size": 100
+}
+```
+
+Loose Tasks deadlines are often null (backlog items without a date). Notion returns null-deadline rows mixed in; sort by `last_edited_time` instead if you want most-recently-touched first.
+
+**Common refinements (paste-ready):**
+
+- Scope Loose Tasks to one Thread (e.g., Everest-side personal): add to the filter — `{ "property": "Thread", "select": { "equals": "Everest" } }`.
+- Coursework due in the next 7 days: replace the Due Date sort with a filter — `{ "property": "Due Date", "date": { "next_week": {} } }`.
+- Overdue coursework: `{ "property": "Due Date", "date": { "before": "<today ISO>" } }` combined with `Done = false`.
+
+**Write operations (not yet exercised):** Notion exposes write tools (`NOTION_CREATE_PAGE`, `NOTION_UPDATE_PAGE`, `NOTION_APPEND_BLOCK_CHILDREN`, etc.) via Composio. AIOS is read-only by default; only use writes when explicitly authorized.
+
+---
+
+## Read-only by default
+
+The AIOS doesn't write to Composio toolkits unless Travis explicitly authorizes it for a specific task. That means:
+
+- Don't send Gmail messages, create calendar events, modify Drive files, edit Docs, or write to Granola without express permission.
+- `COMPOSIO_MANAGE_CONNECTIONS` write actions (`add` / `rename` / `remove`) are also gated — confirm with Travis before changing connection state.
+
+Reads are free. Writes require sign-off.
+
+---
+
+## Confidentiality cross-reference
+
+Most Everest content surfaced via Composio (emails, calendars, Drive docs, Granola transcripts) is internal. When derived content goes into the Personal Brain wiki, default to `confidential: internal` on the resulting page unless the source is clearly public.
+
+---
+
+## Tools not yet exercised across the umbrella
+
+- `COMPOSIO_MANAGE_CONNECTIONS` `add` flow — used briefly during onboarding; not currently a routine AIOS action.
+- New toolkits Travis has connected but the AIOS hasn't queried (`apify`, `exa`, `firecrawl`, `github`, `linkedin`, `notion`, `supabase`, etc.) — document per-toolkit reference docs when first exercised.
+- `COMPOSIO_REMOTE_WORKBENCH` for non-trivial Python pipelines on large Composio response files — useful pattern when a one-shot query returns more than fits inline.

--- a/references/fireflies-mcp.md
+++ b/references/fireflies-mcp.md
@@ -1,0 +1,109 @@
+---
+bike-method-phase: 1  # Phase 1 — Training wheels. Run manually first.
+three-ms-attribution: |
+  Adapted from The Three Ms of AI™ © 2026 Nate Herk.
+---
+
+# Fireflies MCP — reference for the AIOS
+
+Fireflies is reached through the Composio MCP server (`mcp__mcp-router__COMPOSIO_*`). This file is a workflow reference for the things Travis actually does with Fireflies — not a tool catalog (those schemas are discoverable via `COMPOSIO_SEARCH_TOOLS`).
+
+**Connection:** single account, `fireflies_relink-spacer`, no alias needed.
+
+**Tied to:** the Personal Brain wiki INGEST workflow at `/Users/tpeng2025/Documents/Personal Brain/CLAUDE.md` §4a. Fireflies is the upstream source (parallel to Granola); the wiki is the destination.
+
+**Channel IDs (Travis's setup):**
+
+| Channel ID | What it holds |
+|---|---|
+| `6a0c1cec7610454b44024df2` | **Everest channel** — work meetings (~5 in Apr–May 2026 inventory) |
+| `6a0c1e3554702d1c5aa6d4e3` | Personal / family — Family Dinner, Project House Cleanup, etc. |
+| `6a0c1e84ffa599853238be96` | Date-stamped catch-all — auto-titled recordings like `"Apr 30, 09:35 AM"` |
+| `[]` (empty channels array) | One-off recordings — Game Night, Roblox Night, ad-hoc captures |
+
+---
+
+## When to use which tool
+
+Four tools matter for the wiki workflow. Picked by question shape:
+
+| If the question is… | Use | Why |
+|---|---|---|
+| "What did we say / decide / agree about X?" — open-ended, with citations | `FIREFLIES_CREATE_ASK_FRED_THREAD` with `channel_ids: ["6a0c1cec7610454b44024df2"]` to scope to Everest | Natural-language query across meetings. Continue threads with `FIREFLIES_CONTINUE_ASK_FRED_THREAD`. Best default. |
+| "List meetings in <date range>" — inventory | `FIREFLIES_GET_TRANSCRIPTS` with `from_date` + `to_date` (ISO 8601 with timezone) | Metadata only. **No channel filter on this tool** — filter client-side on `channels[]`. |
+| "Get the transcript for one meeting (have the ID)" | `FIREFLIES_GET_TRANSCRIPT_BY_ID` with `include_sentences: true` | Verbatim sentences with speaker labels + timestamps. |
+| "Find a meeting whose title I don't quite remember" | `FIREFLIES_CREATE_ASK_FRED_THREAD` ("find the meeting about X — return ID and date") | Returns IDs you can pass to GET_TRANSCRIPT_BY_ID. |
+
+**Default chain when ingesting one Fireflies meeting into the wiki:**
+LIST_TRANSCRIPTS over a date window → filter client-side on `channels[0].id === "6a0c1cec7610454b44024df2"` → pick the one → GET_TRANSCRIPT_BY_ID with `include_sentences: true` → format speaker labels → write `raw/meetings/<slug>.md`.
+
+---
+
+## Critical gotchas
+
+These bite repeatedly if not internalized.
+
+- **Channel filter only works on AskFred.** `FIREFLIES_GET_TRANSCRIPTS` has no channel parameter. Filter client-side on each transcript's `channels[]` array (length 0 or 1).
+- **Response is nested deep.** `FIREFLIES_GET_TRANSCRIPT_BY_ID` returns the transcript at `data.outputs.data.transcript`, not at the top level. `data.transcripts` for LIST_TRANSCRIPTS.
+- **Auto-titled meetings are common.** Many entries are titled `"Apr 30, 09:35 AM"` — Fireflies doesn't always derive a meaningful title. Open the transcript, derive a descriptive slug from content, and use *that* for `raw/meetings/YYYY-MM-DD-<topic>.md` instead of the auto-title.
+- **`sentences` and `attendees` can be null.** Always defensive-check. If sentences is null, the transcript may still be useful via the summary, but for the raw file you want verbatim — skip and flag.
+- **`summary.action_items` may be a single newline-delimited string, not a list.** Split by `\n` rather than iterating.
+- **`from_date` / `to_date` need ISO 8601 with timezone.** `"2026-04-01T00:00:00Z"` works; `"2026-04-01"` does not.
+- **Time fields are UTC.** Convert to PDT for display in raw files (subtract 7 hours during DST). The `dateString` field is already ISO.
+- **`duration` appears to be in minutes** (decimal), not seconds. Verify on a known-length meeting before relying on it.
+- **Skip transcripts with non-`processed` status.** `meeting_info.summary_status` of `"skipped"` or `"failed"` means partial / missing content. Filter to `"processed"` only before fetching.
+- **Pagination uses `skip` + `limit`; max limit is 50.** 429s on rapid requests — apply exponential backoff, respect `Retry-After`.
+
+---
+
+## INGEST workflow (Fireflies → Personal Brain wiki)
+
+Same shape as the Granola flow. The wiki's INGEST is at `/Users/tpeng2025/Documents/Personal Brain/CLAUDE.md` §4a.
+
+1. **Identify the meeting.** If title is known: LIST_TRANSCRIPTS over the date window, filter for Everest channel, match. If fuzzy: AskFred to surface a candidate ID by content.
+2. **Fetch the verbatim transcript.** `GET_TRANSCRIPT_BY_ID` with `include_sentences: true`. The `sentences` array has `{speaker_name, text, start_time, end_time}` per line.
+3. **Format speaker labels.** Fireflies speakers may be named (`"Apurba"`, `"Travispeng"`) or anonymized (`"Speaker 1"`, `"Speaker 2"`). Preserve exactly as returned — don't relabel.
+4. **Write the raw file** at `Personal Brain/raw/meetings/YYYY-MM-DD-<slug>.md`. Include: title (descriptive, not the auto-title if auto), date/time (converted to PDT), attendees (from `meeting_attendees` if populated, otherwise `speakers[]`), Fireflies transcript ID, then verbatim transcript reconstructed from the sentences array. `raw/` is immutable after write.
+5. **Run the wiki INGEST** per CLAUDE.md §4a steps 2–9: discuss takeaways, create `wiki/sources/<slug>.md`, update touched people/concepts/techniques/tools/customers, append to `wiki/log.md`, update `wiki/index.md`.
+
+---
+
+## Naming conventions for ingested files
+
+- Raw transcript file: `raw/meetings/YYYY-MM-DD-<participants-or-topic>.md`.
+- Wiki source page: mirror the raw filename in `wiki/sources/<same-slug>.md`.
+- Slug is all-lowercase, hyphenated. No spaces, no underscores.
+- For auto-titled Fireflies meetings, derive the slug from transcript content — don't preserve the date-stamp title.
+
+---
+
+## Useful repeat queries
+
+- **"What was discussed in the Everest channel about <topic> in <date range>?"** — AskFred with `channel_ids: ["6a0c1cec7610454b44024df2"]` and the date filter. Channel scoping prevents personal-channel contamination.
+- **"Find the meeting where <event happened>"** — AskFred natural-language; returns IDs to pass to GET_TRANSCRIPT_BY_ID.
+- **"List all my Everest-channel meetings in May."** — GET_TRANSCRIPTS for May, then filter on `channels[0].id`.
+- **"Compare what was decided across these two Avinash meetings."** — AskFred with `transcript_ids: [id1, id2]` for scoped multi-meeting synthesis.
+
+---
+
+## Fireflies vs Granola — when to use which
+
+- **Granola** is the primary capture for Everest meetings as of May 2026. Better LLM-derived titles, better summaries, no channel structure needed.
+- **Fireflies** catches what Granola misses for Everest work (some Zoom calls — architecture + engineering sessions in May 2026 appear here but not in Granola). Channel-based filtering is the discriminator.
+- **Same meeting in both** is possible. Default to Granola as canonical when overlap is detected; ingest the Fireflies version only if it has unique value (e.g., better speaker labeling, a longer recording).
+- **For backlog ingest:** check both sources for each date. Cross-reference the inventory before writing a raw file to avoid double-ingesting the same meeting under different slugs.
+
+---
+
+## Confidentiality cross-reference
+
+Same rule as Granola. Everest meeting content surfaced via Fireflies → default `confidential: internal` on the resulting wiki source page unless the meeting is clearly public-facing.
+
+---
+
+## Tools not yet exercised
+
+- `FIREFLIES_GRAPHQL_QUERY` — read-only GraphQL passthrough. Powerful escape hatch for queries the named tools don't cover; document a working example once one is needed.
+- AskFred with `transcript_ids` for scoped multi-meeting synthesis — useful for comparison-page candidates in the wiki.
+- `FIREFLIES_CREATE_BITE` — extract a video/audio clip from a transcript range. Not part of the wiki path but useful for sharing soundbites.
+- `FIREFLIES_GET_USERS` — resolve team members' emails if the channel filter alone isn't enough.

--- a/references/granola-mcp.md
+++ b/references/granola-mcp.md
@@ -1,0 +1,91 @@
+---
+bike-method-phase: 1  # Phase 1 — Training wheels. Run manually first.
+three-ms-attribution: |
+  Adapted from The Three Ms of AI™ © 2026 Nate Herk.
+---
+
+# Granola MCP — reference for the AIOS
+
+Granola is reached through the Composio MCP server (`mcp__mcp-router__COMPOSIO_*`). This file is not a tool catalog (the schemas are self-documenting via `COMPOSIO_SEARCH_TOOLS`) — it's a workflow reference for the things Travis actually does with Granola.
+
+**Connection:** single account, `granola_mcp_gainly-micro`, no alias needed.
+
+**Tied to:** the [[Personal Brain wiki]] INGEST workflow at `/Users/tpeng2025/Documents/Personal Brain/CLAUDE.md` §4a. Granola is the upstream source; the wiki is the destination.
+
+---
+
+## When to use which tool
+
+Four tools, picked by question shape, not by name. Always favor the one closest to the natural question.
+
+| If the question is… | Use | Why |
+|---|---|---|
+| "What did we say / decide / agree about X?" — open-ended, across meetings | `GRANOLA_MCP_QUERY_GRANOLA_MEETINGS` | RAG with citations back to source meetings. Best default. |
+| "List meetings in <window>" — scanning the calendar of conversations | `GRANOLA_MCP_LIST_MEETINGS` | Returns titles + IDs + dates only. Cheap. |
+| "Give me the full notes / summary for these specific meetings" (have IDs) | `GRANOLA_MCP_GET_MEETINGS` | Up to 10 meeting IDs per call. Returns private notes + AI summary + attendees. |
+| "Quote the exact words from one meeting" | `GRANOLA_MCP_GET_MEETING_TRANSCRIPT` | Verbatim transcript. One meeting per call. |
+
+**Default chain when ingesting a meeting into the wiki:** `QUERY` (to find the right meeting if title is fuzzy) → `LIST` to confirm + grab the ID → `GET_MEETINGS` for the AI summary → `GET_MEETING_TRANSCRIPT` for the raw transcript that goes into `raw/meetings/`.
+
+---
+
+## Time-range parameter cheatsheet (LIST_MEETINGS)
+
+- `this_week`, `last_week`, `last_30_days` — relative, easiest.
+- `custom` with `custom_start` + `custom_end` (ISO `YYYY-MM-DD`) — for older history.
+- The tool returns ~50–100 meetings per call without complaining; older meetings carry the same shape.
+
+**Gotcha:** Granola dates are returned in PDT (the server's reported timezone, e.g. "May 13, 2026 2:30 PM PDT"). Composio's session metadata exposes current UTC. Reconcile when computing "this week."
+
+---
+
+## QUERY behavior worth knowing
+
+- Response includes inline citation links like `[[0]](url)` pointing back to specific Granola meeting notes. **Preserve these in any report.**
+- Queries can be scoped to specific meetings by passing `document_ids: [uuid, uuid, ...]`. Useful for "summarize this specific stretch of meetings" without contamination from unrelated conversations.
+- Querying for "what has X assigned me" or "what's open on Y project" pulls a surprisingly complete operational picture — better than reading any single transcript, because Granola RAGs across all relevant meetings and synthesizes.
+
+---
+
+## INGEST workflow (Granola → Personal Brain wiki)
+
+The wiki's INGEST workflow lives in `/Users/tpeng2025/Documents/Personal Brain/CLAUDE.md` §4a. Granola is upstream of step 1. Concretely:
+
+1. **Identify the meeting.** If the title is exact, jump to LIST → grab ID. If fuzzy, run QUERY to surface candidate IDs first.
+2. **Fetch transcript + AI summary** in one parallel call: `GET_MEETING_TRANSCRIPT` (for `raw/meetings/`) + `GET_MEETINGS` (for orientation).
+3. **Write the raw file** at `Personal Brain/raw/meetings/YYYY-MM-DD-<short-slug>.md`. Include: title, date/time, attendees, Granola meeting UUID, Granola AI summary (for orientation only), then verbatim transcript. `raw/` is immutable after this — never edit.
+4. **Run the wiki INGEST** per the wiki's CLAUDE.md §4a steps 2–9: discuss takeaways, create the `wiki/sources/<slug>.md` page, update touched people/concepts/techniques/tools/customers, append to `wiki/log.md`, update `wiki/index.md`.
+
+**Cite the Granola UUID** in the raw file's frontmatter or first line. It's the cheapest way to re-fetch the source if the transcript ever needs to be regenerated.
+
+---
+
+## Naming conventions for ingested files
+
+- **Raw transcript file:** `raw/meetings/YYYY-MM-DD-<participants-or-topic>.md`. Examples: `2026-03-11-alfiya-salesforce-cleanup.md`, `2026-05-13-apurba-onboarding.md`.
+- **Wiki source page:** mirror the raw filename in `wiki/sources/<same-slug>.md` per the wiki's schema §2.
+- Slug is all-lowercase, hyphenated. No spaces, no underscores.
+
+---
+
+## Useful repeat queries
+
+Save these as starting points. Adjust the date scope or subject as needed.
+
+- **"What has Apurba assigned me to work on for the Navigator product and the POCs? List concrete deliverables and deadlines."** — pulls the full POC + deliverables + deadlines rundown across all Apurba meetings in scope. Citation-backed.
+- **"Find the meeting with <person> about <topic>. Return meeting ID, date, and a one-line summary."** — fastest way to locate a meeting when only the topic is remembered.
+- **"What open follow-ups did I leave on <customer> across recent calls?"** — surfaces commitments by customer.
+- **"Compare what <person A> said about <topic> versus <person B> across meetings."** — feeds a comparison page candidate for the wiki.
+
+---
+
+## Confidentiality cross-reference
+
+Most Everest meeting content surfaced via Granola is internal (customer names, pricing, personnel, deal state). When the resulting wiki source page is created, default to `confidential: internal` per the wiki's CLAUDE.md §3.1 unless the meeting is clearly public-facing material. Re-read the wiki's confidentiality rules before each ingest — the wiki schema evolves.
+
+---
+
+## Tools not yet exercised
+
+- Multi-meeting queries with `document_ids` scoping — not yet hit; document a working example once one is produced.
+- Whether `last_30_days` includes the current day — empirically yes, but worth noting if a meeting is missing.

--- a/references/jira-mcp.md
+++ b/references/jira-mcp.md
@@ -1,0 +1,306 @@
+---
+bike-method-phase: 1  # Phase 1 — Training wheels. Run manually first.
+three-ms-attribution: |
+  Adapted from The Three Ms of AI™ © 2026 Nate Herk.
+---
+
+# JIRA (Atlassian) MCP — reference for the AIOS
+
+JIRA is reached through the Atlassian MCP server (`mcp__claude_ai_Atlassian__*`) — a separate connector from Composio. The same connector also exposes **Confluence**, with read/write scopes for both products on Everest's site.
+
+## Connection facts (constants)
+
+- **Cloud ID:** `e830597d-ffd6-4aed-a34b-e0bbb574db04`
+- **Site URL:** `https://everestlabs.atlassian.net`
+- **Authenticated user:** Travis Peng (`travis@everestlabs.ai`), Associate GTM Intern, Operations team. Atlassian account created 2026-02-02.
+- **Scopes:**
+  - Jira: `read:jira-work`, `write:jira-work`
+  - Confluence: `read:page`, `write:page`, `read:comment`, `write:comment`, `read:space`, `read:confluence-user`, `search:confluence`
+
+Pass `cloudId` on every Jira/Confluence call. Don't hardcode it in callers; reference it from this doc (or call `getAccessibleAtlassianResources` once to verify if it changes).
+
+---
+
+## How Jira is used at Everest (org context)
+
+The Jira structure at Everest is being **formalized in real time as of 2026-05-19** by Apurba with the engineering core (Anish, Ravi, Sid). The wider POC team isn't on this structure yet — broader adoption + onboarding is mid-flight and is on Travis.
+
+### Two active workspaces
+
+| Workspace | Board type | Sprint cadence | What lives here |
+|---|---|---|---|
+| **Navigator (`NAV`)** | Scrum | Two-week sprints | All Navigator product engineering work. ~6 epics covering line / process / plant levels (4 boxes each). Stories ≤ 4 story points (≤ 2 weeks). |
+| **POC (`POC`)** | Kanban | Continuous | Customer-facing POC work. **One epic per customer** (Caglia, Circular Services, RSG OEE, etc.) with stories + subtasks underneath. Travis's home base. |
+
+**`L2` is being deprecated** in favor of Navigator. Was set up as Kanban and Apurba needed Scrum for the release cycle; rather than convert, he stood Navigator up fresh. Don't write new tickets to L2; existing L2 work is being migrated.
+
+### Issue hierarchy
+
+`Epic → Story → Sub-task`. Bugs are treated as Stories (same hierarchy level, just labeled). Stories should be ≤ 4 story points (~15 days / 2 weeks max). If bigger, break into multiple stories under the same epic.
+
+### Status workflow (as of 2026-05-19)
+
+Five statuses on the Navigator scrum board:
+
+| Status | Means |
+|---|---|
+| **To Do** | Accepted into a sprint but not started. |
+| **In Progress** | Actively being worked. |
+| **In Review** | Implementation done, waiting on review / sign-off. (Added 2026-05-19.) |
+| **Hold** | Blocked by something the assignee can't unblock alone. Can sit here indefinitely. (Added 2026-05-19.) |
+| **Done** | Implemented + unit-tested + accepted. Definition-of-done required at end of green planning phase (see release cycle below). |
+
+### Release cycle (3-month staggered, monthly cadence)
+
+Each release moves through three monthly phases:
+
+| Phase | Color | What happens | Vocabulary |
+|---|---|---|---|
+| **Plan** (month 1) | green | Apurba/PM hands requirements; engineering scopes, architects, picks technologies, defines done. Output: committed feature list + DoD for each. | "Green box" |
+| **Execute** (month 2) | yellow | Coding, unit testing, internal demo at the end. PM clarifications minimized. | "Yellow box" / **alpha** (Everest-side) |
+| **Field QA** (month 3) | blue | Deploy at customer site, gather feedback, fix issues, finalize. Engineering moves on to next release's execute phase while this runs. | "Blue box" / **beta** (customer-side) |
+
+Cycles **stagger** — every month, the team is simultaneously planning release `N+2`, executing `N+1`, and field-testing `N`. As of May 2026: planning July release + executing June release + field-QA May release.
+
+End of each phase has a deliverable:
+- **End of green:** committed feature list with definition-of-done.
+- **End of yellow:** internal demo of the alpha. UI is part of every demo plan.
+- **End of blue:** customer-ready ship.
+
+### Commitment discipline
+
+Engineering changes commitments only **once a month** (at planning). Mid-month replanning should be < 10% of the time — only for exceptional events ("Apurba just signed Ecology and we need X now" or "we started Grafana and it's the wrong tech"). Otherwise: lock the commitment, ship the commitment.
+
+### Cross-project dependencies
+
+When POC needs work in NAV / ENG / another team's Jira:
+
+1. Create the dependency as an `is blocked by` link between the POC issue and the upstream issue.
+2. **Don't mirror tickets across projects.** One source of truth per piece of work; link instead.
+3. **The owner of the upstream issue owns the conversation.** If Travis's POC ticket is blocked by a NAV ticket, Travis goes to whoever owns the NAV ticket.
+
+This is the model Apurba designed and that the team is just now standing up.
+
+### Check-ins
+
+Two recurring forums (being formalized):
+
+- **Navigator sync** — engineering core (Anish, Ravi, Sid, + Travis for cross-link visibility). Weekly. Discuss Navigator scrum board state.
+- **POC sync** — Travis + customer-side stakeholders. Weekly, 15 minutes. Discuss the POC kanban board.
+
+Apurba and Avinash join either as needed; their tickets show up via `is blocked by` links.
+
+### Adoption status
+
+- **On the structure (as of May 19):** Anish, Ravi, Sid, Travis. Engineering core.
+- **Not yet on:** wider engineering (Valeria, Purvang, others maintain their own jiras elsewhere — linked in as dependencies but not yet sprint participants); broader POC team / customer-side counterparts.
+- **Onboarding others is on Travis** for the POC side. Until that's done, JQL queries that try to walk the full POC → engineering dependency chain will hit gaps.
+
+---
+
+## Projects (Jira — Everest's instance has 13)
+
+| Key | Name | Type | What it tracks |
+|---|---|---|---|
+| `POC` | POC | software | **Travis's home project. Kanban.** POC features (Caglia, Republic OEE, Circular Services) — one Epic per customer with Stories tagged by priority (P1, etc.) and Subtasks for HW val / HW deploy / model fine-tune / data dashboard. Travis is assignee on multiple. |
+| `NAV` | Navigator | software | **Active Navigator product workspace. Scrum, 2-week sprints.** Set up 2026-05-19 to replace L2. ~6 epics covering line/process/plant levels. Tasks / Bugs / Stories / Epics / Subtasks. |
+| `L2` | L2: Vision & Data Capabilities | software | **Deprecating** as of 2026-05-19. Was Kanban; Apurba needed Scrum for the new release cycle so Navigator was stood up fresh instead of converting. Existing L2 work being migrated; don't write new tickets here. |
+| `ENG` | Engineering | software | Engineering team's general work. Tasks + Epics + Subtasks. |
+| `CORE` | Core | software | Core platform work. Tasks + Bugs + Epics + Subtasks. |
+| `CI` | Customer Installations | business | Customer deployment tracking. Full issue type set (Task / Story / Bug / Epic / Sub-task). |
+| `PI` | Product Installations | software | Product-side install tracking. |
+| `PB` | Production Builds | software | |
+| `POI` | Production Open Issues | software | |
+| `RR` | R&D Robot | software | Robot R&D. |
+| `DPUC` | Deployment Process - Under Construction | business | Process development. |
+| `PART` | Partnerships | software | |
+| `WT` | Web Tools | classic | Older classic-style project. |
+
+**For Travis's daily work**, the load-bearing projects are `POC` (home), `NAV` (cross-link target for engineering dependencies), and (less so) `ENG`. `L2` is on its way out.
+
+---
+
+## When to use which tool
+
+| If the question is… | Use | Why |
+|---|---|---|
+| "Find issues matching <criteria>" | `searchJiraIssuesUsingJql` with a JQL query | Full JQL power. Specify `fields` to control response size. Default `responseContentFormat: "markdown"` is cheaper than ADF. |
+| "Get one issue's full state" | `getJiraIssue` with `issueIdOrKey` | Key like `POC-6` or numeric ID. Use `responseContentFormat: "markdown"` for descriptions/comments. |
+| "List visible projects" | `getVisibleJiraProjects` with `action: "view"` | Includes `issueTypes` per project. Useful to discover Epic / Story / Subtask IDs for project-specific creation. |
+| "What can I transition this issue to?" | `getTransitionsForJiraIssue` then `transitionJiraIssue` | Workflow-aware. Don't guess transition IDs. |
+| "What issue link types exist?" | `getIssueLinkTypes` then `createIssueLink` | Use for the "POC depends on engineering" link Apurba described. |
+| "Look up someone by name → accountId" | `lookupJiraAccountId` | Needed to filter by `assignee = "<accountId>"`. |
+| "Add a comment" | `addCommentToJiraIssue` with `responseContentFormat: "markdown"` | Write a markdown comment; ADF is auto-converted server-side. |
+| "Log work" | `addWorklogToJiraIssue` | Time tracking; minor for Travis's workflow but available. |
+| "What can I currently transition issues to?" | `getJiraProjectIssueTypesMetadata` | Useful before `createJiraIssue` to know required fields per type. |
+
+**Default chain for POC status briefing:**
+`searchJiraIssuesUsingJql` with `jql: "project = POC AND assignee = currentUser() AND statusCategory != Done ORDER BY priority DESC, updated DESC"` → for each interesting result, `getJiraIssue` (markdown) for the full state.
+
+**Default chain for surfacing dependencies on a customer-feature:**
+`getJiraIssue` for the feature → check `issuelinks` field → for each linked engineering issue, `getJiraIssue` to see status.
+
+---
+
+## JQL essentials Travis will actually use
+
+```
+# My open POC work
+project = POC AND assignee = currentUser() AND statusCategory != Done
+
+# This week's activity across Travis's projects
+(project = POC OR project = NAV) AND updated >= -7d ORDER BY updated DESC
+
+# Recently created — what's new
+project = POC AND created >= -7d ORDER BY created DESC
+
+# Feature-level (Stories only) in POC
+project = POC AND issuetype = Story ORDER BY priority DESC
+
+# Search Caglia-related issues across all projects
+text ~ "Caglia" ORDER BY updated DESC
+
+# Issues blocking a specific issue
+issue in linkedIssues("POC-6", "is blocked by")
+
+# Open P1 issues
+labels = "P1" AND statusCategory != Done
+
+# Apurba assigned
+assignee = "<apurba's accountId from lookupJiraAccountId>" AND updated >= -14d
+```
+
+---
+
+## Critical gotchas
+
+- **`searchJiraIssuesUsingJql` output can be huge.** A broad query (`updated >= -30d` across all projects) overflows the response limit and spills to a file on disk. Always narrow with `project = X`, `assignee = ...`, or `updated >= -7d`. Use `maxResults` (cap 100) and `fields` array to control size.
+- **Use `responseContentFormat: "markdown"` for descriptions/comments.** Default ADF (Atlassian Document Format) is structured JSON — fidelity is higher but token cost is ~3x. Reserve ADF for when you specifically need to preserve formatting for a write-back.
+- **Pagination via `nextPageToken`.** Pass it back as `nextPageToken` argument until `isLast: true` or token absent.
+- **Project keys are case-sensitive in some contexts.** Always use UPPERCASE in JQL: `project = POC` not `project = poc`.
+- **`assignee = currentUser()`** is the cleanest filter for "my work." Avoids hardcoding `accountId`. But for "filter by other person," you must look up their `accountId` first via `lookupJiraAccountId`.
+- **Status vs statusCategory.** `status = "Done"` matches exact status names; `statusCategory = Done` matches all done-category statuses (Done, Closed, Resolved, etc.). Prefer `statusCategory` for "anything done" filters. Navigator status set (2026-05-19): `"To Do"`, `"In Progress"`, `"In Review"`, `"Hold"`, `"Done"`. `In Review` and `Hold` map to `statusCategory = "indeterminate"`.
+- **Issue types vary by project.** Each project has its own issue type IDs (visible via `getVisibleJiraProjects` with `expandIssueTypes: true`). Don't pass an issue type ID from POC to a NAV `createJiraIssue` call.
+- **Labels.** Multi-value. `labels = "P1"` to filter; case-sensitive. P1, P2 visible so far.
+- **`addCommentToJiraIssue` / `editJiraIssue` are write ops.** AIOS is read-only by default. Only use when explicitly authorized by Travis.
+
+---
+
+## Use cases
+
+### 1. Weekly POC status brief
+
+Friday afternoon: pull all POC project changes from the past week, grouped by status category. Feeds the Friday review and Sunday plan-the-week.
+
+```jql
+project = POC AND updated >= -7d ORDER BY status, updated DESC
+```
+
+### 2. Pre-meeting briefer (POC sync)
+
+Before a POC-related meeting, pull the relevant feature epics and their subtasks:
+
+```jql
+project = POC AND (key = POC-6 OR parent = POC-6)
+```
+
+Combined with wiki context from `wiki/customers/<customer>.md`, produces a one-pager.
+
+### 3. Surface dependencies (the Apurba workflow)
+
+Per the May 13 onboarding meeting, the work model is: customer-facing feature epics in POC, with explicit `depends on` links to engineering issues in ENG / L2 / NAV. To answer "why isn't this feature ready":
+
+```
+getJiraIssue("POC-<n>") → check issuelinks → for each "is blocked by" link, getJiraIssue on the target
+```
+
+### 4. "What did Apurba assign me this week"
+
+```jql
+project in (POC, NAV) AND reporter = "<apurba_accountId>" AND assignee = currentUser() AND created >= -7d
+```
+
+Surfaces new assignments without trawling email.
+
+### 5. Cross-reference customer-feature with Granola/Fireflies meetings
+
+When ingesting a customer meeting into the wiki:
+- After identifying the customer (e.g., Caglia), JQL search `text ~ "Caglia" AND project = POC` to surface the POC issues that meeting probably touches.
+- Cross-link in the wiki source page: cite the POC issue key alongside the meeting transcript.
+
+### 6. Wiki freshness — JIRA adoption is mid-flight, not binary
+
+The wiki and intake answer say "team not yet active on JIRA." The truth as of 2026-05-19 is more nuanced:
+
+- **Engineering core (Anish, Ravi, Sid, Travis) is on the new structure** — actively churning issues; POC project alone has 34+ issues; Travis is assignee on POC-6, POC-14, POC-19 and others.
+- **Wider engineering** (Valeria, Purvang, others) is on Jira but not yet integrated into the new sprint cadence — their tickets get linked in as `is blocked by` dependencies only.
+- **POC team / customer-side counterparts** are not on the structure at all yet; Travis is onboarding them.
+
+When updating `wiki/concepts/everest-labs.md`, reflect the rollout-in-progress framing rather than picking a side of "active vs not." See `connections.md` for the same nuance.
+
+---
+
+## Issue structure quick reference
+
+Fields most commonly used (Markdown response format):
+
+```
+key                          # POC-6, NAV-12, etc.
+id                           # Numeric internal ID
+summary                      # Short title
+description                  # Body (markdown or ADF depending on responseContentFormat)
+status.name                  # "To Do", "In Progress", "Done", custom names
+status.statusCategory.key    # "new" | "indeterminate" | "done"
+issuetype.name               # "Task" | "Story" | "Bug" | "Epic" | "Subtask"
+priority.name                # When set
+assignee                     # null or {accountId, displayName, emailAddress, timeZone}
+reporter                     # Same shape as assignee
+created                      # ISO timestamp
+updated                      # ISO timestamp
+labels[]                     # Array of label strings — Travis's instance uses P1, etc.
+parent                       # For subtasks, the parent issue key
+issuelinks[]                 # Array of {type, inwardIssue / outwardIssue} for dependencies
+```
+
+---
+
+## Confluence — same connector, separate workflow
+
+The Atlassian MCP also exposes Confluence (read/write pages, comments, search). The wiki names Confluence as the SE-team-owned authoritative per-MRF data source (mentioned in [[2026-03-04-brian-proposal-gen]]). Worth exercising when Travis needs per-MRF context that the wiki doesn't yet capture.
+
+Confluence tools available (not yet exercised here):
+- `mcp__claude_ai_Atlassian__getConfluenceSpaces`
+- `mcp__claude_ai_Atlassian__searchConfluenceUsingCql`
+- `mcp__claude_ai_Atlassian__getConfluencePage`
+- `mcp__claude_ai_Atlassian__getPagesInConfluenceSpace`
+- `mcp__claude_ai_Atlassian__getConfluencePageDescendants`
+
+These deserve their own session pass — defer for now. Worth a future `references/confluence-mcp.md`.
+
+---
+
+## Cross-reference with Personal Brain
+
+JIRA is the operational layer below the wiki:
+
+- **Wiki captures the why, who, and decision context.** Customer pages, person pages, decisions log entries.
+- **JIRA captures the what, when, and dependency state.** Issues, status, transitions, links.
+
+When updating a wiki customer page (e.g., [[republic-services]]), include a section "JIRA references" with the POC and NAV issue keys most relevant — links survive wiki re-renames but stay actionable. (Don't reference L2 keys going forward; that project is being deprecated.)
+
+When ingesting a Granola meeting that produces commitments ("Travis will set up X, Aneesh will fix Y"), consider whether new JIRA issues should be created (in the appropriate project) and link them back in the wiki source page.
+
+---
+
+## Tools not yet exercised
+
+- `getJiraIssueRemoteIssueLinks` — external links on an issue (e.g., to Confluence pages, Drive docs). Useful when a customer-feature epic links to its proposal deck.
+- `getJiraIssueTypeMetaWithFields` — full creation schema for an issue type. Useful before `createJiraIssue` if defaults aren't clear.
+- `getTransitionsForJiraIssue` + `transitionJiraIssue` — workflow transitions. Read-only AIOS unless Travis authorizes writes.
+- `addWorklogToJiraIssue` — time tracking. Not currently used by Travis.
+
+---
+
+## Confidentiality cross-reference
+
+JIRA issue data (customer names, feature scope, dependency state) is internal. When derived content goes into the wiki, default to `confidential: internal` on pages that quote JIRA descriptions or restate customer-feature state.

--- a/references/voice.md
+++ b/references/voice.md
@@ -1,0 +1,41 @@
+# Voice — Travis's register
+
+**Rule for Claude:** Match this register when drafting on Travis's behalf. Casual but professional. Short messages, often one thought per line. Warm but not effusive — sparing exclamation points (`!`), no em dashes. Diplomatic when navigating org dynamics (e.g., not stepping on a manager's toes). Self-aware enough to explain context when something might be misread. Direct asks ("what do you think would be best?"). Don't try to sound like a marketer or a consultant.
+
+**Hard rule:** Don't fake Travis's voice on external content (LinkedIn posts, customer-facing email, anything going outside the company) without showing him a draft first.
+
+---
+
+## Sample 1 — Slack/Flock thread with Mylinda Jacobsen (external contact)
+
+[06/05/2026 12:51 PM] Travis Peng: Mylinda, thanks for the conversation! Hope I didn't seem like I was doing other things near the end because I was telling Katie that I was going to be running late for my meeting scheduled with her
+
+[06/05/2026 12:57 PM] Travis Peng: I can bring up the idea of adding Navigator to the Sarasota vision POC with Apurba tonight from what we talked about, and would love to get the Tom/Jamie/Chris intros whenever convenient. Also if you could share the the case study that would be awesome!
+
+[06/05/2026 1:00 PM] Mylinda Jacobsen: Yes on all
+
+[06/05/2026 1:24 PM] Mylinda Jacobsen: I sent the grey parrot newsletter and I am coordinating with the CS guys
+
+[06/05/2026 1:26 PM] Travis Peng: ok awesome I got it thank you!
+
+[18/05/2026 11:56 AM] Travis Peng: Mylinda, an update on my side. I'm learning more as I go and I want to keep you included! My last conversation with you was very nice, and I remember I was introducing what my idea of Navigator was and we were developing out a vision for what it could be used for and you were very helpful to share your years of experience on things. Now I have a more full picture of Navigator and how we plan to market it aswell as build it out. It seems like Apurba's plan is to use the POCs we have, which includes Caglia, Circular Services, and RSG OEE, as a way to introduce Navigator later on when we are in early stages of development. And he brought be on to manage those POCs which I'm getting more info on as I go. Recently I brought up that you were kind enough to offer intros with the folks at Circular Services to which Apurba said that he'd be working with services on the POC and wouldn't want to do anything extra, which is fair and I don't want to step on Apurba's toes.
+
+[18/05/2026 11:57 AM] Travis Peng: what do you think would be best and how is the status coordinating with the CS guys? and has everything been working well with the Claude skills on Project Jetstream?
+
+---
+
+## Sample 2 — Slack/Flock intro DM to Georgia Seto (internal teammate)
+
+[14/05/2026 1:04 PM] Travis Peng: Hi Georgia! I don't think we've formally met yet. I'd like to introduce myself as the summer Product GTM Associate intern who is working here until end of the summer. As given by Apurba, I'll be the running point on the Navigator POCs and helping with marketing. I feel like we may be working together down the line, so I'm reaching out to connect! If you have the availability, may I schedule a time to meet with you next week? If so, what's your schedule like?
+
+[14/05/2026 2:54 PM] Georgia Seto: Hey Travis! We actually met before and have been in a few zoom calls together. Let me check my calendar next week but yes that sounds good.
+
+[14/05/2026 2:54 PM] Georgia Seto: How about Monday around 130/2pm?
+
+[14/05/2026 3:27 PM] Travis Peng: Oh that's great! I do know
+
+[14/05/2026 3:29 PM] Travis Peng: Yes let's do that
+
+[14/05/2026 3:29 PM] Travis Peng: 1:30 would be great, sending an invite
+
+[14/05/2026 3:43 PM] Georgia Seto: Great! Looking forward to it

--- a/weekly-plans/2026-05-21-substrate.md
+++ b/weekly-plans/2026-05-21-substrate.md
@@ -1,0 +1,172 @@
+# Week-of 2026-05-18 — Substrate (working doc, pre-plan)
+
+Working substrate for /plan-my-week. Reflects grouping per Travis as of 2026-05-21. Status updates captured inline. This is NOT the final plan — Step 5 writes the canonical plan.
+
+## Data model
+Projects are first-class containers. Tasks live under projects. Deadlines optional. Rich context lives in the DB once unified DB design ships.
+
+## WEEK-SHAPING BLOCKER
+Most Claude-dependent tasks WAIT until Fri Claude credit reset → personal wiki ingestion (~2 hrs; needs remaining meetings added; requires knowledge).
+
+**Startable now (Claude-independent):**
+- Application Evaluation (Grafana, Libra, etc.)
+- Vendor List creation
+- Newsletter w/ Makenna
+
+## EVEREST
+
+### 🔵 Navigator Application — 5 projects
+
+#### Project 1. MCP Testing (functional QA)
+- Basic functionality validation
+- A/B testing
+- Scope constraint: Republic_Services only, 7-day window, no `C108` label
+- *Volume blocker: Claude credits until Fri reset*
+
+#### Project 2. Use Case Evaluation (capability check)
+- Test whether MCP + current application architecture can facilitate execution of needed use cases
+- Inputs: list of use cases worth validating (Robot Upsell is one)
+
+#### Project 3. Application Evaluation (chat surface)
+- Grafana light-yellow prompts *(in progress today)*
+- Libra Chat side-by-side eval *(Apurba assigned for Fri)*
+- Open Web UI investigation
+- Onyx investigation
+- A/B test Grafana w/ Sid's MCP skills doc
+- Long-term option: build/own a Libra-Chat Grafana plugin
+- *Claude-independent — can run NOW*
+
+#### Project 4. Internal Rollout (Project Jetstream continuation)
+*Sequenced 1 → 5 strictly. Depends on: outputs from Projects 1+2+3, AND Robot Upsell completing under Caglia as demo material.*
+
+1. Internal onboarding doc (non-technical — only one, no separate technical version)
+2. Travis onboarding gc update
+3. Claude basics video tutorial
+4. Project Jetstream email (internal AI readiness investigation + intro/get-up-to-speed-on-Claude)
+5. Navigator Claude group chat setup
+
+Notion AC entry "Navigator Internal Rollout" (due 5/20) is this workstream. Status: deadline was for plan locked, reevaluating on the go as dependencies move.
+
+#### Project 5. Incident Response automation (Jerry's idea)
+- Standalone, parked for later down the line
+- Replace passive alerts with PIP-style guided workflows
+
+#### Use-case identification
+- **Initial round COMPLETE** (always ongoing background)
+
+---
+
+### 🟠 Caglia POC
+*Wed May 27 data review is the customer anchor. Meetings are not tasks.*
+
+- **JIRA epic/story restructure** — assigned Friday 5/22
+- **Belt utilization + loading dashboards / UI mockups** — for 5/27 data review
+- **Belt-lacing daily workflow** (Ravi handoff 5/20) — pull S3 videos, day-over-day comparison artifact
+- **Belt slippage analysis** — Phase 1 motor fluctuation data, Phase 2 encoder ($2K/line)
+- **Mass balancing project** — 8 commodities, 3-location vision strategy + landfill stream
+- **2D/3D screen optimization** — down the line, no set date
+- **Robot upsell** — sequencing: AFTER Navigator MCP testing, BEFORE Navigator internal rollout; produces a demo use case for the internal rollout
+
+Mylinda follow-up — **DONE 5/18** (was a dependency under Internal Rollout, closed)
+
+---
+
+### 🟢 Central Compute
+- Get Central Compute certification quote (~$10-15k additional; total projected $35-40k)
+- Build certification matrix (Confluence customer-facing + internal spreadsheet)
+- Replace Daniel Schmidt as Fanuc contact for ISO 10218-2
+
+### 🟣 Customer Comms
+- Weekly customer status + industry news newsletter (w/ Makenna) — *Claude-independent, startable now*
+
+### ⚪ Operational
+- Vendor list creation (can wait until after next Thursday) — *Claude-independent, startable now*
+
+### 🔘 Cross-cutting (awareness/calendar — NOT assignments)
+- Twice-weekly PM↔Eng check-ins (calendar; status prep when assignments are due)
+- POC stakeholder meeting cadence (not established yet, will be done)
+- Three-month release cycle (frame: Planning M-2 → Execution M-1 → Field test M; Alpha → Beta) — fit workstreams within
+- *(removed: JIRA workspace consolidation — not owned by Travis)*
+
+---
+
+## ACADEMIC
+
+### INMI0300 close-out (consolidated, one workstream)
+*Travis: "on my mind for review, will do thorough analysis on whether worth doing."*
+
+- Req 2: Library Module (~1.5-2h) — overdue 53 days
+- Req 3a: Faculty Research Conversation — overdue 48 days
+- Req 3b: Event Reflections + Req 3 Write-up — overdue 41 days
+- Req 4: Final Reflection + Badge Quiz (~1h) — overdue 34 days, blocked by Reqs 1-3
+
+---
+
+## BIGSCHOLARS — *parked, to be reevaluated*
+- Analyze NEU finance officer meeting + store insights
+- LLM credits (startup-credits-playbook)
+- Organize docs + business plan
+
+---
+
+## CAREER
+
+### Profile cluster (sequenced after LinkedIn post — DONE 5/18)
+- LinkedIn profile update
+- Resume update
+- Personal website update
+
+### Standalone Career
+- LinkedIn post: Sales/Ops → GTM — **DONE 5/18** (needs Notion close)
+- Ansara blog review outreach (Rhami, Andrey, Josh; Tasmin ↔ Paul Singh) — independent
+- LinkedIn endorsements plan — Deferred to Aug per Naeem
+- Next summer's job (Summer 2027) planning — aspirational
+- Naeem summer email cadence — Deferred (milestone-based)
+- BigScholars (parked, will reevaluate): NEU finance officer analysis, LLM credits, docs + business plan
+
+---
+
+## FAMILY (was Self & Spaces)
+- **Project House Cleanup** — In progress, top of backlog; plan in separate Claude project
+- Family finances + Morgan Stanley conversation (prep this week, not the convo)
+
+---
+
+## PERSONAL (broader; absorbed Galguera + Personal Enrichment)
+
+### Personal Enrichment (sub-group)
+- Course backlog Summer 2026 (CV Tutorials, Parking Lot CV, Ken's Thought Leadership, NEPQ Sales, OMGYes)
+- Real World Crypto course catch-up
+- Journal club exploration (aspirational)
+
+### Personal core
+- Galguera mezcal case study read + feedback — hard wall was May 4, **VERY overdue**, needs decision
+- Sadie apology text (overdue, was bucketed Fri May 1)
+- Coach Enrique re: summer XC
+- Sister tutoring on econ + Claude research (Deferred)
+- Philosophy article — Five-Year-Old PhD Babies (Deferred)
+- HS friends summer regroup (Deferred — wait until late May UC / early June CC)
+
+---
+
+## ADMIN
+- Firestore billing dispute / RealEstateAPI cancel — **bleeding $38.27/mo since Aug 2025, $309+ total**, marked Deferred but probably shouldn't be
+- Set up personal credit card (Deferred)
+
+---
+
+## Cross-pillar dependency spine
+
+```
+{ MCP Testing + Use Case Eval + Application Eval }
+       (3 parallel Navigator projects)
+                ↓
+   Robot Upsell (Caglia → Navigator demo asset)
+                ↓
+       Internal Onboarding Doc (non-tech)
+                ↓
+       Internal Rollout (1→5 sequential)
+```
+
+## Meta — Open thread
+Travis flagged: restructure Loose Tasks + Academic Calendar into ONE unified Notion DB. Projects are first-class; tasks live under them; deadlines optional; rich context in DB. Tackle after this week's plan ships.

--- a/weekly-plans/README.md
+++ b/weekly-plans/README.md
@@ -1,0 +1,71 @@
+# weekly-plans/
+
+One markdown file per week. Each file is a **snapshot of the weekly plan at planning time**, plus an **append-only change log** capturing mid-week shifts.
+
+This folder holds the *planning rationale* — the layer that's about scheduling decisions, not about the work itself. The work itself (Tasks, Projects) lives in Notion. See `references/aios-task-system.md` for the architecture.
+
+## File naming
+
+`{YYYY-MM-DD}.md` where the date is the Monday of the week.
+
+Examples:
+- `2026-05-18.md` — week of Monday May 18
+- `2026-05-25.md` — week of Monday May 25
+
+## File shape
+
+```markdown
+# Week of {Monday date}
+
+## Anchors (locked dates)
+Calendar items + deadlines that shape the week. The fixed points everything else routes around.
+
+Example:
+- Wed 5/27 — Caglia Data Review 10-11:30am
+- Thu 5/28 — Wisdom teeth surgery 8:45-10am (recovery day)
+- Sat-Sun — Google I/O Hack (if confirmed)
+
+## Plan (snapshot — written by /plan-my-week at planning time)
+
+### {Weekday} {Month} {Day} (~Xh free)
+
+- {Task name}  [link to Notion task page]
+  Why this slot: short rationale
+- ...
+
+(repeat per day across the 7-day window)
+
+## Reasoning / context that didn't fit elsewhere
+
+Free-form. Week's center of gravity. Load-bearing pieces. Squeeze points. Strategy notes that apply to the week as a whole.
+
+## Change log (append-only mid-week)
+
+Append entries as the week unfolds. NEVER overwrite the Plan section above; the original snapshot stays intact.
+
+- YYYY-MM-DD HH:MM: <what changed>
+  Why: <reason>
+```
+
+## How this interacts with the Notion task system
+
+- **Notion Tasks DB** = canonical source of *what* the work is + *how* to do it
+- **This file (current week)** = canonical source of *when* the work is scheduled + *why* it landed on that day
+
+A fresh chat session reading both:
+1. Sees today's date
+2. Reads the current week's file → knows what's planned for today + this week's anchors + the reasoning
+3. Queries Notion Tasks DB → gets the actual task details
+4. Cross-references the two
+
+If the plan changes mid-week, the change log captures it here. The underlying Notion task status / deadline updates happen in Notion. Both surfaces update; this file does NOT replace Notion.
+
+## What this folder is NOT
+
+- **Not a content store** for projects or tasks. That's Notion.
+- **Not a permanent record of every change** beyond the week. Once a week passes, the file becomes a historical snapshot. We don't actively maintain it forward in time.
+- **Not a substitute for Notion**. If Notion is unavailable, the week's plan loses its underlying task references.
+
+## Naming pre-existing files
+
+- `2026-05-21-substrate.md` — working substrate from initial system design conversation. Predates the snapshot+change-log shape. Archived in spirit, kept for reference.


### PR DESCRIPTION
## Summary
- Fills in the AIOS starter kit for Travis Peng's role at Everest Labs (Navigator POC rollouts, July GA training, customer warming).
- Wires Composio (Gmail, Calendar, Drive, Docs, Granola, Fireflies) and Atlassian (Jira, Confluence) MCPs into `connections.md` with per-toolkit references under `references/`.
- Seeds `context/` (about-me, about-business, priorities), `decisions/log.md`, `weekly-plans/`, plus an `archives/` snapshot and `AGENTS.md` pointer.

## Test plan
- [ ] Re-run `/onboard` against `aios-intake.md` and confirm idempotency
- [ ] Run `/audit` and check the Four-Cs score reflects the wired connectors

🤖 Generated with [Claude Code](https://claude.com/claude-code)