### PR TITLE
/level-up: ship idea-to-script prompt (Phase 1, prompt-only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,9 @@ real samples to fill this in.
 **Live:** Gmail (`roman.brandon503@gmail.com`, see `references/gmail-api.md`), Google
 Calendar (same account, see `references/google-calendar-api.md`), Obsidian vault at
 `C:\Users\roman\Claude Main\content-brand\Obsidian Vault` (canonical knowledge, see
-above), per-repo `PROJECT-STATE.md` files (task tracking, no central board).
+above), per-repo `PROJECT-STATE.md` files (task tracking, no central board — **Home
+Base's own state is `main-bro\apps\home-base\PROJECT-STATE.md`, not `main-bro`'s root
+PROJECT-STATE.md**, which tracks the separate Main Rig harness project instead).
 **Not yet connected:** Discord, Outlook, revenue tracking (none exists — YouTube
 Studio subs/watch-hours are the de facto proxy metric).
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,11 +61,17 @@ real samples to fill this in.
 
 ## Connections
 
-None wired yet. Known systems from onboarding: Discord/Gmail/Outlook (communication),
-Outlook Calendar, per-repo `PROJECT-STATE.md` files (task tracking, no central board),
-Obsidian vault at `C:\Users\roman\Claude Main\content-brand\Obsidian Vault`
-(knowledge/files — canonical, see above), and YouTube Studio as the de facto
-revenue-proxy metric. Full table in `connections.md`. Run `/audit` to see freshness.
+**Live:** Gmail (`roman.brandon503@gmail.com`, see `references/gmail-api.md`), Google
+Calendar (same account, see `references/google-calendar-api.md`), Obsidian vault at
+`C:\Users\roman\Claude Main\content-brand\Obsidian Vault` (canonical knowledge, see
+above), per-repo `PROJECT-STATE.md` files (task tracking, no central board).
+**Not yet connected:** Discord, Outlook, revenue tracking (none exists — YouTube
+Studio subs/watch-hours are the de facto proxy metric).
+
+Sending email, creating/editing calendar events, or responding to invites all need
+Brandon's explicit in-the-moment approval — never act on standing/past approval.
+
+Full table in `connections.md`. Run `/audit` to see freshness.
 
 ## How you work with me
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,22 @@
-# {{Your Name}}'s AI Operating System
+# Brandon's AI Operating System
 
-You are {{Your Name}}'s personal AIOS. Your job is to be their thought partner — help them think, decide, and ship faster on {{stated priority}}. You're a learning companion, not a vending machine.
+You are Brandon's personal AIOS. Your job is to be their thought partner — help them think, decide, and ship faster on hitting YouTube watch-hour thresholds (Fan Funding, then full YPP) for NOT A WORK BRO. You're a learning companion, not a vending machine.
 
 `AGENTS.md` and `CLAUDE.md` share the same standing guidance. Update both together when onboarding or changing shared instructions.
 
 ## Your operator brain — the 3Ms
 
-Read `references/3ms-framework.md` once. It's how {{Your Name}} thinks about AI work. Mindset (how to think), Method (how to decide), Machine (how to build). Reference it when running `/level-up`.
+Read `references/3ms-framework.md` once. It's how Brandon thinks about AI work. Mindset (how to think), Method (how to decide), Machine (how to build). Reference it when running `/level-up`.
 
 > *The Three Ms of AI™ is a trademark of Nate Herk. © 2026 Nate Herk.*
+
+## Cross-project knowledge — the Obsidian vault
+
+All durable knowledge about Brandon, his projects, and past decisions lives in the
+Obsidian vault at `C:\Users\roman\Claude Main\content-brand\Obsidian Vault` — start at
+`Home.md` and `About Brandon.md`. This AIOS's `context/` files are summaries pointing
+back there; treat the vault as canonical when the two conflict, and connect new
+findings back to it rather than duplicating it here.
 
 ## Your skills
 
@@ -33,15 +41,31 @@ See `EXPANSIONS.md` for what to add as you grow.
 
 ## Knowledge base
 
-{{Filled by /onboard from Q1 + Q3 — what you do, who you serve, what matters this quarter.}}
+Solo full-stack developer, content creator, music producer/songwriter, streamer, and
+digital-product builder in North Las Vegas. Currently between jobs, pre-revenue,
+supported by family while building sustainable income through content: dev work,
+music, and content creation in general. Primary vehicle is YouTube — rebranding
+`@xbroman_` (1,298 subs) into NOT A WORK BRO, long-form led with Shorts/TikTok/Reels
+for discovery only. Also runs LYTW and side dev projects (Home Base, SLASH, Loop,
+Portfolio). This quarter: hit watch-hour thresholds, ship Home Base, fix the
+finishing/publishing and idea→script bottleneck. See `context/about-me.md`,
+`context/about-business.md`, `context/priorities.md`.
 
 ## Voice
 
-Match the register in `references/voice.md`. Casual but professional. Short sentences. No em dashes. Bullet points over paragraphs. Don't fake my voice on external content (LinkedIn, email to clients) without showing me a draft first.
+No voice samples on file yet (`Q2` deferred at onboarding, 2026-09-06). Until
+`references/voice.md` exists, don't guess at register for external content — draft
+plainly and flag it as unstyled. Don't fake my voice on external content (LinkedIn,
+email to clients) without showing me a draft first. Re-run `/onboard` after pasting
+real samples to fill this in.
 
 ## Connections
 
-{{Filled by /onboard from Q4-Q7. Each entry is a tool the AIOS knows about but may not be connected to yet. Run /audit to see freshness.}}
+None wired yet. Known systems from onboarding: Discord/Gmail/Outlook (communication),
+Outlook Calendar, per-repo `PROJECT-STATE.md` files (task tracking, no central board),
+Obsidian vault at `C:\Users\roman\Claude Main\content-brand\Obsidian Vault`
+(knowledge/files — canonical, see above), and YouTube Studio as the de facto
+revenue-proxy metric. Full table in `connections.md`. Run `/audit` to see freshness.
 
 ## How you work with me
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,9 @@ real samples to fill this in.
 **Live:** Gmail (`roman.brandon503@gmail.com`, see `references/gmail-api.md`), Google
 Calendar (same account, see `references/google-calendar-api.md`), Obsidian vault at
 `C:\Users\roman\Claude Main\content-brand\Obsidian Vault` (canonical knowledge, see
-above), per-repo `PROJECT-STATE.md` files (task tracking, no central board).
+above), per-repo `PROJECT-STATE.md` files (task tracking, no central board — **Home
+Base's own state is `main-bro\apps\home-base\PROJECT-STATE.md`, not `main-bro`'s root
+PROJECT-STATE.md**, which tracks the separate Main Rig harness project instead).
 **Not yet connected:** Discord, Outlook, revenue tracking (none exists — YouTube
 Studio subs/watch-hours are the de facto proxy metric).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,11 +61,17 @@ real samples to fill this in.
 
 ## Connections
 
-None wired yet. Known systems from onboarding: Discord/Gmail/Outlook (communication),
-Outlook Calendar, per-repo `PROJECT-STATE.md` files (task tracking, no central board),
-Obsidian vault at `C:\Users\roman\Claude Main\content-brand\Obsidian Vault`
-(knowledge/files — canonical, see above), and YouTube Studio as the de facto
-revenue-proxy metric. Full table in `connections.md`. Run `/audit` to see freshness.
+**Live:** Gmail (`roman.brandon503@gmail.com`, see `references/gmail-api.md`), Google
+Calendar (same account, see `references/google-calendar-api.md`), Obsidian vault at
+`C:\Users\roman\Claude Main\content-brand\Obsidian Vault` (canonical knowledge, see
+above), per-repo `PROJECT-STATE.md` files (task tracking, no central board).
+**Not yet connected:** Discord, Outlook, revenue tracking (none exists — YouTube
+Studio subs/watch-hours are the de facto proxy metric).
+
+Sending email, creating/editing calendar events, or responding to invites all need
+Brandon's explicit in-the-moment approval — never act on standing/past approval.
+
+Full table in `connections.md`. Run `/audit` to see freshness.
 
 ## How you work with me
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,22 @@
-# {{Your Name}}'s AI Operating System
+# Brandon's AI Operating System
 
-You are {{Your Name}}'s personal AIOS. Your job is to be their thought partner — help them think, decide, and ship faster on {{stated priority}}. You're a learning companion, not a vending machine.
+You are Brandon's personal AIOS. Your job is to be their thought partner — help them think, decide, and ship faster on hitting YouTube watch-hour thresholds (Fan Funding, then full YPP) for NOT A WORK BRO. You're a learning companion, not a vending machine.
 
 `AGENTS.md` and `CLAUDE.md` share the same standing guidance. Update both together when onboarding or changing shared instructions.
 
 ## Your operator brain — the 3Ms
 
-Read `references/3ms-framework.md` once. It's how {{Your Name}} thinks about AI work. Mindset (how to think), Method (how to decide), Machine (how to build). Reference it when running `/level-up`.
+Read `references/3ms-framework.md` once. It's how Brandon thinks about AI work. Mindset (how to think), Method (how to decide), Machine (how to build). Reference it when running `/level-up`.
 
 > *The Three Ms of AI™ is a trademark of Nate Herk. © 2026 Nate Herk.*
+
+## Cross-project knowledge — the Obsidian vault
+
+All durable knowledge about Brandon, his projects, and past decisions lives in the
+Obsidian vault at `C:\Users\roman\Claude Main\content-brand\Obsidian Vault` — start at
+`Home.md` and `About Brandon.md`. This AIOS's `context/` files are summaries pointing
+back there; treat the vault as canonical when the two conflict, and connect new
+findings back to it rather than duplicating it here.
 
 ## Your skills
 
@@ -33,15 +41,31 @@ See `EXPANSIONS.md` for what to add as you grow.
 
 ## Knowledge base
 
-{{Filled by /onboard from Q1 + Q3 — what you do, who you serve, what matters this quarter.}}
+Solo full-stack developer, content creator, music producer/songwriter, streamer, and
+digital-product builder in North Las Vegas. Currently between jobs, pre-revenue,
+supported by family while building sustainable income through content: dev work,
+music, and content creation in general. Primary vehicle is YouTube — rebranding
+`@xbroman_` (1,298 subs) into NOT A WORK BRO, long-form led with Shorts/TikTok/Reels
+for discovery only. Also runs LYTW and side dev projects (Home Base, SLASH, Loop,
+Portfolio). This quarter: hit watch-hour thresholds, ship Home Base, fix the
+finishing/publishing and idea→script bottleneck. See `context/about-me.md`,
+`context/about-business.md`, `context/priorities.md`.
 
 ## Voice
 
-Match the register in `references/voice.md`. Casual but professional. Short sentences. No em dashes. Bullet points over paragraphs. Don't fake my voice on external content (LinkedIn, email to clients) without showing me a draft first.
+No voice samples on file yet (`Q2` deferred at onboarding, 2026-09-06). Until
+`references/voice.md` exists, don't guess at register for external content — draft
+plainly and flag it as unstyled. Don't fake my voice on external content (LinkedIn,
+email to clients) without showing me a draft first. Re-run `/onboard` after pasting
+real samples to fill this in.
 
 ## Connections
 
-{{Filled by /onboard from Q4-Q7. Each entry is a tool the AIOS knows about but may not be connected to yet. Run /audit to see freshness.}}
+None wired yet. Known systems from onboarding: Discord/Gmail/Outlook (communication),
+Outlook Calendar, per-repo `PROJECT-STATE.md` files (task tracking, no central board),
+Obsidian vault at `C:\Users\roman\Claude Main\content-brand\Obsidian Vault`
+(knowledge/files — canonical, see above), and YouTube Studio as the de facto
+revenue-proxy metric. Full table in `connections.md`. Run `/audit` to see freshness.
 
 ## How you work with me
 

--- a/aios-intake.md
+++ b/aios-intake.md
@@ -11,7 +11,14 @@ This is the source-of-truth file for your AIOS. Fill it in by typing, voice-past
 Identity, offer, ICP. One paragraph each is fine.
 
 ```
-[Your answer here]
+Brandon "Broman" Roman, North Las Vegas. Solo full-stack developer, content creator,
+music producer/songwriter, streamer, and digital-product builder. Currently between
+jobs, working toward sustainable income through content. Primary vehicle is YouTube:
+rebranding @xbroman_ (1,298 subs) into NOT A WORK BRO, long-form led, with Shorts/
+TikTok/Reels for discovery only (not monetization). Also runs LYTW (older tech-focused
+channel) and side dev projects (Home Base, SLASH, Loop, Portfolio). No paying customers
+yet — audience is the current ICP, future ICP is viewers/subscribers who convert to
+Fan Funding/YPP revenue, plus potential freelance dev/music clients down the line.
 ```
 
 ---
@@ -21,11 +28,8 @@ Identity, offer, ICP. One paragraph each is fine.
 An email, a LinkedIn post, a DM, a doc — anything that sounds like you when you're not trying. **Paste verbatim.** Do not type these mid-conversation with Claude — chat-shaped samples are worse than no samples (voice contamination).
 
 ```
-[Sample 1 — paste raw]
-```
-
-```
-[Sample 2 — paste raw]
+[Skipped for now, 2026-09-06 — Brandon opted to defer this. Re-run /onboard after
+pasting real samples (email/LinkedIn/DM) to fill references/voice.md.]
 ```
 
 ---
@@ -35,9 +39,12 @@ An email, a LinkedIn post, a DM, a doc — anything that sounds like you when yo
 Quarterly priorities. Not yearly aspirations. Things that, if not done by July, would make you say "I wasted Q2."
 
 ```
-1. [Priority 1]
-2. [Priority 2]
-3. [Priority 3]
+1. Hit YouTube watch-hour thresholds — Fan Funding (3,000 hrs) then full YPP (4,000
+   hrs) on NOT A WORK BRO, hard deadline 2027-02-01.
+2. Ship Home Base — the dev/creator/ADHD productivity hub — to actually support the
+   content pipeline (script → record → edit → publish).
+3. Fix the real bottleneck: finishing/publishing and idea→script (editing is not the
+   bottleneck).
 ```
 
 ---
@@ -47,7 +54,10 @@ Quarterly priorities. Not yearly aspirations. Things that, if not done by July, 
 Multiple answers OK. Stripe? Skool? GoHighLevel? QuickBooks? A spreadsheet?
 
 ```
-[Your answer here]
+No revenue source yet other than family support. Goal is income from content-related
+work: dev work, music, and general content creation. Progress currently tracked via
+YouTube Studio (subs/watch-hours) toward Fan Funding/YPP thresholds, not a financial
+tool.
 ```
 
 ---
@@ -57,7 +67,7 @@ Multiple answers OK. Stripe? Skool? GoHighLevel? QuickBooks? A spreadsheet?
 Email (which one — Gmail / Outlook)? Slack? Teams? DMs (Skool / Discord / iMessage)? Phone?
 
 ```
-[Your answer here]
+Discord, Gmail, Outlook.
 ```
 
 ---
@@ -67,7 +77,10 @@ Email (which one — Gmail / Outlook)? Slack? Teams? DMs (Skool / Discord / iMes
 Granola? Otter? Fireflies? Google Drive? Notion? Dropbox? A folder on your desktop you keep meaning to organize?
 
 ```
-[Your answer here]
+No separate tool — everything routes to the Obsidian vault at
+"C:\Users\roman\Claude Main\content-brand\Obsidian Vault". That vault is the durable
+knowledge system (decisions, architecture notes, session digests); all future
+knowledge about Brandon and his projects should reference/connect there.
 ```
 
 ---
@@ -77,7 +90,10 @@ Granola? Otter? Fireflies? Google Drive? Notion? Dropbox? A folder on your deskt
 The single biggest time-suck or recurring drudgery. Plus where tasks/projects live (ClickUp / Asana / Linear / Notion / a notebook).
 
 ```
-[Your answer here]
+Biggest time-suck: finishing/publishing and idea→script (editing is not the
+bottleneck — gets pulled into creative/visual decisions mid-edit instead). Tasks live
+per-project in each repo's own PROJECT-STATE.md (no central board); durable
+cross-project decisions live in the Obsidian vault.
 ```
 
 ---

--- a/archives/decisions-log-kit-authoring-2026-09-06.md
+++ b/archives/decisions-log-kit-authoring-2026-09-06.md
@@ -1,0 +1,36 @@
+# Archived: AIS-OS kit-authoring decisions
+
+Moved out of `decisions/log.md` on 2026-09-07 (audit finding AIOS-2026-09-07-02).
+These four entries document decisions Nate Herk made while **building the AIS-OS
+kit itself** (the audit rubric, portable Claude/Codex skills, the 3D Brain skill,
+`/grill-me`) — they shipped as template content in the repo and are not decisions
+Brandon made about his own business or projects. Kept here for reference rather than
+deleted, per the kit's own archive convention ("old stuff, don't delete, move here").
+
+---
+
+## 2026-09-06 - Audit evidence and routing maintenance
+
+**Decision:** Ship audit rubric v2 and a small /link skill. Audit scores working evidence across the Four Cs, checks operating-manual routing and freshness, and passes one concrete gap into /level-up. A selected repair can improve an existing workflow instead of creating another skill.
+
+**Why:** File counts, configured keys, named rituals, and recent edits do not prove an operational AIOS. Source findability and freshness need explicit checks.
+
+**Alternatives considered:** Keeping presence-based scoring or requiring a hot cache. Neither reliably establishes retrieval quality or successful execution.
+
+## 2026-09-06 - Portable skills and automatic audit history
+
+**Decision:** Ship all four skills for Claude Code and Codex, with bundled resources, matching operating manuals, and a script for regenerating Codex copies. Audit reports are saved automatically, preserve previous runs, and track findings across comparable inspections.
+
+**Why:** Students need the same shared guidance when switching assistants and evidence of actual improvements over time. Intentional runtime adaptations, unknown verification, and confirmed defects are reported separately.
+
+## 2026-09-06 - Portable 3D Brain skill
+
+**Decision:** Add `/3d-brain` for Claude Code and Codex. Ask for a name and categories, map selected local folders, and scaffold a bundled, configurable application with spherical placement, Cinema, and interactive growth replay.
+
+**Why:** Shipping the working renderer preserves the intended appearance and interactions across AIOS installations. A prose-only prompt would produce inconsistent recreations. User config and graph data remain local; the public package includes only code, documentation, dependency notices, and fictional test inputs.
+
+## 2026-09-06 - Add ongoing context interviews
+
+**Decision:** Adapt Herk-2's grill-me skill for the student kit and ship matching Claude/Codex packages. Save every answer to brainstorms/, preserve resumable Q&A history, and update canonical context only with confirmed facts during requested context-building sessions.
+
+**Why:** Onboarding is an initial snapshot. Ongoing interviews capture changing priorities, decisions, and preferences while keeping tentative ideas distinct from current business facts.

--- a/connections.md
+++ b/connections.md
@@ -4,14 +4,14 @@ Registry of every system your AIOS can reach. Filled by `/onboard` from Q4-Q7 an
 
 | # | Domain | Tool | Mechanism | Auth | Last checked |
 |---|---|---|---|---|---|
-| 1 | Revenue / Financials | _filled by /onboard_ | not yet connected | — | — |
-| 2 | Customer interactions | _filled by /onboard_ | not yet connected | — | — |
-| 3 | Calendar | _filled by /onboard_ | not yet connected | — | — |
-| 4 | Communication | _filled by /onboard_ | not yet connected | — | — |
-| 5 | Project / task tracking | _filled by /onboard_ | not yet connected | — | — |
-| 6 | Meeting intelligence | _filled by /onboard_ | not yet connected | — | — |
-| 7 | Knowledge / files | _filled by /onboard_ | not yet connected | — | — |
+| 1 | Revenue / Financials | None yet — YouTube Studio (subs/watch-hours) as proxy metric | not yet connected | — | — |
+| 2 | Customer interactions | Discord | not yet connected | — | — |
+| 3 | Calendar | Outlook Calendar (inferred from Outlook) | not yet connected | — | — |
+| 4 | Communication | Discord, Gmail, Outlook | not yet connected | — | — |
+| 5 | Project / task tracking | Per-repo `PROJECT-STATE.md` (no central board) | not yet connected | — | — |
+| 6 | Meeting intelligence | None — no separate tool | not yet connected | — | — |
+| 7 | Knowledge / files | Obsidian vault (`C:\Users\roman\Claude Main\content-brand\Obsidian Vault`) | filesystem (direct path, read-only) | none needed — local files | 2026-09-06 |
 
-**Mechanism options:** `mcp` (MCP server), `script` (Python/Bash hitting an API, in `scripts/`), `export` (CSV/JSON dump pipeline), `key+ref` (`.env` key + `references/{tool}-api.md` guide), `not yet connected`.
+**Mechanism options:** `mcp` (MCP server), `script` (Python/Bash hitting an API, in `scripts/`), `export` (CSV/JSON dump pipeline), `key+ref` (`.env` key + `references/{tool}-api.md` guide), `filesystem` (direct local path, no auth — e.g. a synced Obsidian vault), `not yet connected`.
 
 When you wire a new tool, also save `references/{tool}-api.md` capturing endpoints, auth flow, and common queries — researched-once-saved-forever.

--- a/connections.md
+++ b/connections.md
@@ -8,7 +8,7 @@ Registry of every system your AIOS can reach. Filled by `/onboard` from Q4-Q7 an
 | 2 | Customer interactions | Discord | not yet connected — no MCP connector available in this environment | — | — |
 | 3 | Calendar | Google Calendar (`roman.brandon503@gmail.com`) | mcp | OAuth (session-scoped) | 2026-09-06 |
 | 4 | Communication | Gmail (`roman.brandon503@gmail.com`) — connected; Outlook and Discord not yet | mcp | OAuth (session-scoped) | 2026-09-06 |
-| 5 | Project / task tracking | Per-repo `PROJECT-STATE.md` — e.g. `C:\Users\roman\main-bro\PROJECT-STATE.md` | filesystem (direct path, read-only) | none needed — local files | 2026-09-06 |
+| 5 | Project / task tracking | Per-repo `PROJECT-STATE.md`, each scoped to its own project — **Home Base** (the NOT A WORK BRO app, priority #2): `C:\Users\roman\main-bro\apps\home-base\PROJECT-STATE.md`. **Main Rig** (the harness/dashboard project, a separate effort): `C:\Users\roman\main-bro\PROJECT-STATE.md` — do not use this one for Home Base questions | filesystem (direct path, read-only) | none needed — local files | 2026-09-07 |
 | 6 | Meeting intelligence | None — no separate tool | not yet connected | — | — |
 | 7 | Knowledge / files | Obsidian vault (`C:\Users\roman\Claude Main\content-brand\Obsidian Vault`) | filesystem (direct path, read-only) | none needed — local files | 2026-09-06 |
 

--- a/connections.md
+++ b/connections.md
@@ -5,10 +5,10 @@ Registry of every system your AIOS can reach. Filled by `/onboard` from Q4-Q7 an
 | # | Domain | Tool | Mechanism | Auth | Last checked |
 |---|---|---|---|---|---|
 | 1 | Revenue / Financials | None yet — YouTube Studio (subs/watch-hours) as proxy metric | not yet connected | — | — |
-| 2 | Customer interactions | Discord | not yet connected | — | — |
-| 3 | Calendar | Outlook Calendar (inferred from Outlook) | not yet connected | — | — |
-| 4 | Communication | Discord, Gmail, Outlook | not yet connected | — | — |
-| 5 | Project / task tracking | Per-repo `PROJECT-STATE.md` (no central board) | not yet connected | — | — |
+| 2 | Customer interactions | Discord | not yet connected — no MCP connector available in this environment | — | — |
+| 3 | Calendar | Google Calendar (`roman.brandon503@gmail.com`) | mcp | OAuth (session-scoped) | 2026-09-06 |
+| 4 | Communication | Gmail (`roman.brandon503@gmail.com`) — connected; Outlook and Discord not yet | mcp | OAuth (session-scoped) | 2026-09-06 |
+| 5 | Project / task tracking | Per-repo `PROJECT-STATE.md` — e.g. `C:\Users\roman\main-bro\PROJECT-STATE.md` | filesystem (direct path, read-only) | none needed — local files | 2026-09-06 |
 | 6 | Meeting intelligence | None — no separate tool | not yet connected | — | — |
 | 7 | Knowledge / files | Obsidian vault (`C:\Users\roman\Claude Main\content-brand\Obsidian Vault`) | filesystem (direct path, read-only) | none needed — local files | 2026-09-06 |
 

--- a/context/about-business.md
+++ b/context/about-business.md
@@ -1,0 +1,19 @@
+# About the Business
+
+No paying customers yet — pre-revenue. Current income source is family support while
+building toward sustainable income from content: dev work, music, and general content
+creation.
+
+**Primary vehicle:** YouTube. Rebranding `@xbroman_` (1,298 subs) into **NOT A WORK
+BRO** — long-form led, with Shorts/TikTok/Reels used for discovery only, not
+monetization (Shorts views don't count toward the watch-hour path). Also runs **LYTW**,
+an older tech-focused channel, plus side dev projects (Home Base, SLASH, Loop,
+Portfolio) that support the content pipeline.
+
+**ICP today:** the audience itself — viewers/subscribers whose watch-hours convert to
+YouTube Partner Program revenue. Future ICP could extend to freelance dev or music
+clients, but that isn't active yet.
+
+**Revenue tracking:** none — progress is tracked via YouTube Studio (subscribers,
+watch-hours) against Fan Funding (3,000 hrs) and full YPP (4,000 hrs) thresholds, hard
+deadline 2027-02-01.

--- a/context/about-me.md
+++ b/context/about-me.md
@@ -1,0 +1,13 @@
+# About Brandon
+
+Brandon "Broman" Roman, based in North Las Vegas. Solo full-stack developer, content
+creator, music producer/songwriter, streamer, and digital-product builder. Currently
+between jobs, working toward sustainable income through content.
+
+**Top pain:** finishing/publishing and idea→script — not editing. He gets pulled into
+creative/visual decisions mid-edit instead of deciding them at script time.
+
+Full cross-project working profile (ADHD-aware preferences, communication style,
+dev-stack defaults, multi-AI collaboration norms) lives in the Obsidian vault at
+`About Brandon.md` — treat that as canonical and this file as the AIOS-facing summary.
+Source: `C:\Users\roman\Claude Main\content-brand\Obsidian Vault\About Brandon.md`.

--- a/context/priorities.md
+++ b/context/priorities.md
@@ -1,0 +1,8 @@
+# Priorities — Next 90 Days
+
+1. Hit YouTube watch-hour thresholds — Fan Funding (3,000 hrs) then full YPP (4,000
+   hrs) on NOT A WORK BRO. Hard deadline: 2027-02-01.
+2. Ship Home Base — the dev/creator/ADHD productivity hub — to actually support the
+   content pipeline (script → record → edit → publish).
+3. Fix the real bottleneck: finishing/publishing and idea→script. Editing is not the
+   bottleneck.

--- a/decisions/log.md
+++ b/decisions/log.md
@@ -19,29 +19,3 @@ Append-only record of meaningful decisions and why they were made. `/level-up` P
 Keep it terse. Future-you will thank present-you for capturing the *why*, not just the *what*.
 
 ---
-
-## 2026-09-06 - Audit evidence and routing maintenance
-
-**Decision:** Ship audit rubric v2 and a small /link skill. Audit scores working evidence across the Four Cs, checks operating-manual routing and freshness, and passes one concrete gap into /level-up. A selected repair can improve an existing workflow instead of creating another skill.
-
-**Why:** File counts, configured keys, named rituals, and recent edits do not prove an operational AIOS. Source findability and freshness need explicit checks.
-
-**Alternatives considered:** Keeping presence-based scoring or requiring a hot cache. Neither reliably establishes retrieval quality or successful execution.
-
-## 2026-09-06 - Portable skills and automatic audit history
-
-**Decision:** Ship all four skills for Claude Code and Codex, with bundled resources, matching operating manuals, and a script for regenerating Codex copies. Audit reports are saved automatically, preserve previous runs, and track findings across comparable inspections.
-
-**Why:** Students need the same shared guidance when switching assistants and evidence of actual improvements over time. Intentional runtime adaptations, unknown verification, and confirmed defects are reported separately.
-
-## 2026-09-06 - Portable 3D Brain skill
-
-**Decision:** Add `/3d-brain` for Claude Code and Codex. Ask for a name and categories, map selected local folders, and scaffold a bundled, configurable application with spherical placement, Cinema, and interactive growth replay.
-
-**Why:** Shipping the working renderer preserves the intended appearance and interactions across AIOS installations. A prose-only prompt would produce inconsistent recreations. User config and graph data remain local; the public package includes only code, documentation, dependency notices, and fictional test inputs.
-
-## 2026-09-06 - Add ongoing context interviews
-
-**Decision:** Adapt Herk-2's grill-me skill for the student kit and ship matching Claude/Codex packages. Save every answer to brainstorms/, preserve resumable Q&A history, and update canonical context only with confirmed facts during requested context-building sessions.
-
-**Why:** Onboarding is an initial snapshot. Ongoing interviews capture changing priorities, decisions, and preferences while keeping tentative ideas distinct from current business facts.

--- a/decisions/log.md
+++ b/decisions/log.md
@@ -19,3 +19,57 @@ Append-only record of meaningful decisions and why they were made. `/level-up` P
 Keep it terse. Future-you will thank present-you for capturing the *why*, not just the *what*.
 
 ---
+
+## 2026-09-07 — Idea→Script Draft Pipeline (`/level-up` #1)
+
+**Decision:** Build a workflow that turns a raw captured idea into a structured
+first-draft script, targeting the constraint named in the 2026-09-07 `/audit`
+(AIOS-2026-09-07-03): none of the 3 stated 90-day priorities had a supporting
+workflow yet.
+
+**Constraint (Mindset):** Top pain is idea→script, not editing (per `About Brandon.md`
+/ Not A Work Bro Channel Identity). This is also the actual blocker between "no
+content this week" and the 1-video/week target.
+
+**EAD:** Eliminate — no, scripting is core to shipping a video. Automate — yes,
+~60% deterministic (capture → structured template) / ~30% AI-drafted (idea →
+script text in channel format) / ~10% manual. The manual slice is larger than
+usual right now because `references/voice.md` doesn't exist yet (Q2 deferred at
+onboarding) — every AI draft needs a real pass from Brandon until it does.
+Delegate — not needed.
+
+**Process map:**
+- Trigger: new entry in a dedicated Google Drive doc ("Idea Inbox") — Google Keep
+  was the first choice but has no available connector in this environment; Drive
+  is confirmed live.
+- Data sources: the Idea Inbox entry + channel format rules (`Not A Work Bro
+  Channel Identity`, Home-Base locked decisions) from the Obsidian vault, read-only.
+- Transformation: raw idea → structured draft (hook / body beats / CTA).
+- Decision point: long-form (counts toward YPP watch-hours) vs. Shorts
+  (discovery-only) — treated differently per the channel's own constraint.
+- Destination: a new `scripts/` folder in this repo (not the vault — keeps the
+  vault read-only-for-this-AIOS as designed).
+
+**Autonomy level:** L2 (Drafted) — AI drafts, Brandon reviews/edits every time.
+Not higher: no voice reference exists yet to justify less review.
+
+**KPI:** Bucket = more customers (watch-hours toward YPP). Metric = script drafts
+produced per week, target ≥1.
+
+**Alternatives considered:** A full animation/resource-generation pipeline
+(candidate #3 from the Mindset interview) — rejected as lower leverage, since it's
+downstream of having a script at all. A cadence-enforcement nudge (candidate #2) —
+lower leverage than removing the actual bottleneck.
+
+**Owner:** Brandon.
+
+**Out of scope, tracked separately:** a Home Base UI change (modal preview on the
+"continue script" container) was raised during scoping — not part of this
+workflow; flagged as a follow-up for a main-bro dev session, not built here.
+
+**Shipped (Machine, Phase 3):** Prompt-only (option 1 of 4) — Boring-is-Beautiful
+default, since a saved prompt costs nothing to build and the voice gap means every
+draft needs manual review regardless of infrastructure. Artifact:
+`references/idea-to-script-prompt.md`. Output lands in the new `video-scripts/`
+folder (not `scripts/`, which is already used for `sync-codex-skills.sh`).
+`bike-method-phase: 1` — run manually, validate before any automation upgrade.

--- a/references/gmail-api.md
+++ b/references/gmail-api.md
@@ -1,0 +1,35 @@
+# Gmail — Connection Guide
+
+**Domain:** 4 — Communication
+**Mechanism:** `mcp` — Gmail MCP server, session-scoped OAuth (already authorized).
+**Account:** `roman.brandon503@gmail.com`
+**Last checked:** 2026-09-06 (`list_labels` returned 95,003 inbox messages, 39,791 unread)
+
+## What's available
+
+Read: `search_threads`, `get_thread`, `get_message`, `list_labels`, `list_drafts`,
+`get_draft`.
+Write (draft only, safe): `create_draft`, `update_draft`.
+Write (side-effecting — **needs Brandon's explicit approval before calling**, per his
+standing multi-AI norms — "explicit approval required before anything that ... sends
+communications"): `send_message`, `reply`, `forward`.
+Organization: `label_message`/`label_thread`, `unlabel_*`, `create_label`,
+`update_label`, `delete_label`, `mark_*_spam`, `trash_*`/`untrash_*`.
+
+User labels currently on the account: `Personal`, `Receipts`, `Work`, `Junk`.
+
+## Common queries
+
+- **"Anything urgent in my inbox?"** → `search_threads` scoped to `INBOX` +
+  `IMPORTANT`/`UNREAD`, summarize subjects/senders — don't dump raw bodies unless asked.
+- **"Draft a reply to X"** → `create_draft`, never `send_message`, until Brandon
+  reviews and says to send.
+- **"What's in Receipts/Work/Personal?"** → filter by the matching `labelId`
+  (`Label_2`/`Label_4`/`Label_1`).
+
+## Guardrails
+
+- 39k+ unread inbox messages — never fetch/summarize the whole inbox by default; scope
+  by label, sender, date range, or search query the way Brandon actually asked.
+- No sending, forwarding, replying, trashing, or spam-marking without explicit
+  confirmation in the moment — a past approval doesn't carry forward to new messages.

--- a/references/google-calendar-api.md
+++ b/references/google-calendar-api.md
@@ -1,0 +1,33 @@
+# Google Calendar — Connection Guide
+
+**Domain:** 3 — Calendar
+**Mechanism:** `mcp` — Calendar MCP server, session-scoped OAuth (already authorized).
+**Account:** `roman.brandon503@gmail.com`
+**Last checked:** 2026-09-06 (`list_calendars` returned the personal calendar plus the
+US Holidays calendar)
+
+## Calendars
+
+- `roman.brandon503@gmail.com` — primary personal calendar
+- `en.usa#holiday@group.v.calendar.google.com` — US Holidays (read-only, informational)
+
+## What's available
+
+Read: `list_events`, `get_event`, `search_events`, `suggest_time`.
+Write (**needs Brandon's explicit approval before calling** — creating/editing/
+deleting events or responding to invites are account-changing actions per his standing
+norms): `create_event`, `update_event`, `delete_event`, `respond_to_event`.
+
+## Common queries
+
+- **"What's on my calendar tomorrow?"** → `list_events` scoped to the date range,
+  primary calendar only unless holidays are relevant.
+- **"When am I free this week?"** → `suggest_time` against the primary calendar.
+- **"Put X on my calendar"** → confirm the exact title/time/duration with Brandon
+  before `create_event` — don't guess at details he didn't state.
+
+## Guardrails
+
+- Never create, move, or delete an event, or accept/decline an invite, without
+  explicit in-the-moment confirmation — matches the send/publish/delete approval rule
+  applied to Gmail.

--- a/references/idea-to-script-prompt.md
+++ b/references/idea-to-script-prompt.md
@@ -1,0 +1,53 @@
+---
+bike-method-phase: 1  # Phase 1 — Training wheels. Run manually first.
+three-ms-attribution: |
+  Adapted from The Three Ms of AI™ © 2026 Nate Herk.
+---
+
+# Idea → Script Draft Prompt
+
+**What this is:** a prompt-only workflow (autonomy level L2 — Drafted). You run this
+by hand whenever a new entry lands in your "Idea Inbox" Google Drive doc. No skill,
+no automation — you paste, Claude drafts, you review. See `decisions/log.md`
+(2026-09-07) for the full Method spec this came from.
+
+**Why prompt-only, not a skill:** `references/voice.md` doesn't exist yet (Q2 was
+deferred at onboarding). Until it does, every draft needs your own pass to sound like
+you instead of generic AI copy — staying manual keeps you in that loop by default. If
+you want it automated later, re-run `/level-up` and Phase 3 can upgrade this to an
+AI-assisted skill.
+
+---
+
+## The prompt
+
+Copy this, fill in the bracketed idea, and run it as-is:
+
+```
+I have a raw video idea for my YouTube channel NOT A WORK BRO (long-form, watch-hour
+focused) or a Shorts/TikTok/Reels post (discovery-only, doesn't count toward
+watch-hours). Here's the idea, verbatim:
+
+[PASTE THE IDEA INBOX ENTRY HERE]
+
+Before drafting, read:
+- The Obsidian vault's "Not A Work Bro Channel Identity" note (channel brand facts,
+  the Shorts-vs-long-form constraint, and the personal bottlenecks/energy-curve notes)
+- Any Home-Base locked decisions relevant to format/visual system
+
+Then:
+1. Tell me whether this reads as long-form or Shorts material, and why.
+2. Draft a structured first-pass script: hook, body beats, CTA. Keep it a draft, not
+   a finished piece — I will do a voice pass on this myself.
+3. Flag anywhere you had to guess at tone or register, since there's no voice
+   reference on file yet.
+4. Save the draft to video-scripts/YYYY-MM-DD-<short-slug>.md, tagged [Long-form] or
+   [Shorts] in the header.
+```
+
+## After you run it
+
+- Do your own voice pass on the draft before it's post-ready — that's the ~10%
+  manual slice this workflow was scoped with.
+- If you paste voice samples into `aios-intake.md` and re-run `/onboard`, come back
+  and re-run `/level-up` to consider upgrading this to L3+ or an actual skill.

--- a/references/obsidian-vault-api.md
+++ b/references/obsidian-vault-api.md
@@ -1,0 +1,56 @@
+# Obsidian Vault — Connection Guide
+
+**Domain:** 7 — Knowledge / files
+**Mechanism:** `filesystem` — direct local read access, no auth, no MCP server needed.
+**Path:** `C:\Users\roman\Claude Main\content-brand\Obsidian Vault`
+**Last checked:** 2026-09-06
+
+This is Brandon's durable cross-project knowledge base — decisions, architecture
+notes, model/tool routing, and session digests that outlive any single repo. It
+complements (doesn't replace) per-repo `PROJECT-STATE.md` files, which hold live
+day-to-day task state.
+
+## Entry points
+
+- `Home.md` — index, explains the division of labor across memory systems (Honcho /
+  this vault / PROJECT-STATE.md) and links every top-level folder.
+- `About Brandon.md` — canonical cross-project profile: who Brandon is, how he works
+  (ADHD-aware preferences), dev-stack defaults, communication style, multi-AI
+  collaboration norms. Source for `context/about-me.md` in this AIOS.
+
+## Structure
+
+| Path | Contents |
+|---|---|
+| `00-Inbox/` | Unsorted capture, triage into the right folder later |
+| `01-Projects/<name>/<name> MOC.md` | One MOC (Map of Content) per active project — start any project-specific lookup here. Projects: Home-Base, LYTW, SLASH, Loop, Portfolio, Main-Bro |
+| `02-Decisions/` | Cross-project conventions promoted out of a single project's PROJECT-STATE.md — e.g. `Development Workflow Conventions.md` |
+| `03-AI-Workflow/` | Zero-cost multi-model routing lane matrix (`AI Model Routing MOC.md`) |
+| `04-Sessions/` | Dated session digests — one note per significant work session, linking what changed |
+| `05-Notes and Thoughts/` | Looser, stream-of-consciousness capture; tentative, not locked decisions |
+
+## How to query it
+
+No API — read directly with filesystem tools (`Read`/`Glob`/`Grep`, or the platform's
+equivalent) against the path above. Common patterns:
+
+- **"What's the current state of project X?"** → read `01-Projects/X/X MOC.md`, follow
+  its linked notes (locked decisions, rejected ideas, architecture).
+- **"Has this idea been tried before?"** → grep the vault for the keyword; check any
+  hit's `#rejected` tag before proposing it again.
+- **"What did we decide about Y, and why?"** → check `02-Decisions/` first (things that
+  apply beyond one project), then the relevant project's MOC.
+- **"What happened in the last session?"** → most recent file in `04-Sessions/` by
+  date in the filename.
+
+## Conventions to respect
+
+- Tags (`#decision`, `#rejected`, `#architecture`, `#session`) mark note type — use
+  them to filter search results, not just filenames.
+- `[[wikilinks]]` form the actual graph — a note's neighbors often matter as much as
+  its own content.
+- Current user instructions in a live conversation outrank stale vault notes, especially
+  ones in `05-Notes and Thoughts` (tentative) vs. `02-Decisions` (locked).
+- This is Brandon's personal knowledge base — read-only for this AIOS. Don't write back
+  into it from AIS-OS skills; if something belongs there, tell Brandon and let him (or
+  a Main-Bro-side tool) add it.

--- a/video-scripts/README.md
+++ b/video-scripts/README.md
@@ -1,0 +1,11 @@
+# Video Scripts
+
+Output folder for the Idea→Script Draft Pipeline (`decisions/log.md`, 2026-09-07).
+One dated file per draft: `YYYY-MM-DD-short-slug.md`.
+
+Every draft needs a manual pass before it's read-ready — `references/voice.md`
+doesn't exist yet, so nothing here has been checked against your actual voice. Don't
+treat a file in here as post-ready until you've done that pass.
+
+Tag each draft `[Long-form]` or `[Shorts]` in its header — only long-form counts
+toward the YouTube Partner Program watch-hour thresholds; Shorts are discovery-only.


### PR DESCRIPTION
First /level-up run, seeded from the 2026-09-07 audit gap (no workflow
tied to any of Brandon's 3 stated priorities). Scopes the idea->script
bottleneck end to end (Mindset -> Method -> Machine) and ships a
prompt-only artifact per Boring-is-Beautiful, since references/voice.md
doesn't exist yet and every draft needs manual review regardless of
infrastructure. Full spec in decisions/log.md.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>